### PR TITLE
Add release notes for v0.1.0

### DIFF
--- a/docs/release_notes/0.1.0.md
+++ b/docs/release_notes/0.1.0.md
@@ -1,9 +1,124 @@
-# Release 0.1.0
 
-## Features
+# Release v0.1.0
 
-## Improvements
+A simple command to run Grafana LGTMP Stack in Docker or Kubernetes.
 
-## Bug Fixes
+## What's Changed
 
-## Acknowledgments
+- Improve sync rules to mimir cluster (#68)
+- chore: rename from docker-compose.yaml to compose.yaml (#66)
+- Docker Compose(traces): Enable caches (#56)
+- Minio: Support  Minio Metrics V3 API (#52)
+- Docker Compose: add --env-file support (#48)
+- Take Grafana LGTMP Stack to the command line (#32)
+- Showcase: agent module auto loading integrations (#19)
+- Creating a registry proxy / pull-through registry (#18)
+
+## 🚀 Features
+
+- Add option to collect metrics (#58)
+- Docker Compose(profiles): Profiles Ingestion via Labels (#51)
+- Add pyroscope-mixin support (#50)
+- Docker Compose(metrics): Metric Ingestion via Labels (#49)
+- Docker Compose(logs): Log Ingestion via Labels (#47)
+- Kubernetes(traces): add metrics\_generator (#39)
+- Take Grafana LGTMP Stack to the command line (#25)
+- Kubernetes: mimir-distributed for Metrics (#17)
+- [Metrics] Add support deploy microservices mode in kubernetes (#7)
+- Add support include feature in docker-compose v2.20 (#6)
+- Add docker microservices mode metrics (#5)
+- Add-microservices-mode-logs (#4)
+- Add Read-Write mode - Metrics (#1)
+
+## 🎯 Improvements
+
+- Update draft release (#72)
+- add common grafana and grafana-agent (#69)
+- Metrics: Agent add cAdvisor integration (#64)
+- Agents always enable metrics collection (#63)
+- Separate dashboards rules and alerts provisioning (#62)
+- Bump Pyroscope to 1.5.0 (#61)
+- Kubernetes(LGTMP): Enable caches (#60)
+- Kubernetes: charts config(loki mimir tempo pyroscope) in monolithic-mode  update (#59)
+- Gateway(nginx): Defaulte env variable  values with entrypoint scripts (#57)
+- Docker Compose(logs): Enable caches (#55)
+- Docker Compose(metrics): Enable caches in monolithic-mode (#54)
+- Avoid restarting grafana (#44)
+- Bump grafana-agent to 0.40.2 (#42)
+- Bump to Tempo 2.4.0 (#38)
+- Bump Pyroscope to 1.4.0 (#34)
+- update loki to 2.9.3 (#28)
+- Mimirtool load rules instead of prometheus (#2)
+
+## ⬆️ Dependencies
+
+<details>
+<summary>30 changes</summary>
+
+- Bump Pyroscope to 1.5.0 (#61)
+- Bump github.com/prometheus/common from 0.49.0 to 0.50.0 (#46)
+- Move to https://github.com/qclaogui/agent-modules.git (#45)
+- Bump to grafana 10.4.0 (#43)
+- Bump grafana-agent to 0.40.2 (#42)
+- Bump github.com/prometheus/common from 0.48.0 to 0.49.0 (#41)
+- Bump github.com/stretchr/testify from 1.8.4 to 1.9.0 (#40)
+- Bump to Tempo 2.4.0 (#38)
+- Bump dagger.io/dagger from 0.9.10 to 0.9.11 (#37)
+- Bump github.com/prometheus/common from 0.46.0 to 0.47.0 (#36)
+- Bump dagger.io/dagger from 0.9.8 to 0.9.9 (#35)
+- Bump Pyroscope to 1.4.0 (#34)
+- update grafana to 10.3.1 (#31)
+- grafana/loki:2.9.4 (#30)
+- Bump dagger.io/dagger from 0.9.6 to 0.9.7 (#29)
+- update loki to 2.9.3 (#28)
+- Bump Mimir to 2.11.0 (#27)
+- Bump Pyroscope to 1.3.0 (#26)
+- Bump dagger.io/dagger from 0.9.5 to 0.9.6 (#24)
+- Bump github.com/stretchr/testify from 1.8.3 to 1.8.4 (#22)
+- Bump dagger.io/dagger from 0.9.1 to 0.9.4 (#21)
+- Bump dagger.io/dagger from 0.9.0 to 0.9.1 (#15)
+- Bump dagger.io/dagger from 0.8.8 to 0.9.0 (#14)
+- Bump dagger.io/dagger from 0.8.7 to 0.8.8 (#13)
+- Bump dagger.io/dagger from 0.8.5 to 0.8.7 (#12)
+- Bump dagger.io/dagger from 0.8.4 to 0.8.5 (#11)
+- Bump actions/checkout from 3 to 4 (#10)
+- Bump dagger.io/dagger from 0.8.2 to 0.8.4 (#9)
+- Bump dagger.io/dagger from 0.8.1 to 0.8.2 (#8)
+- Bump dagger.io/dagger from 0.7.4 to 0.8.1 (#3)
+</details>
+
+## New Contributors
+
+
+🎉 **Thanks to all contributors helping with this release!** 🎉
+## Grafana LGTMP Stack default port-mapping
+
+| Port-mapping | Component | Description |
+| --- | --- | --- |
+| , , ,  | [Grafana Agent][1] | Eexpose  port so we can directly access  inside container |
+|  | [Loki][2] | Expose  port so we can directly access  inside container |
+| ,  | [Grafana][3] | Expose  port so we can directly access  inside container |
+| , ,  | [Tempo][4] | Expose  port so we can directly access  inside container |
+|  | [Mimir][5] | Expose  port so we can directly access  inside container |
+|  | [Pyroscope][6] | Expose  port so we can directly access  inside container |
+| ,  | [Minio][7] | Expose  port so we can access  console with ,  |
+
+[1]: https://github.com/grafana/agent
+[2]: https://github.com/grafana/loki
+[3]: https://github.com/grafana/grafana
+[4]: https://github.com/grafana/tempo
+[5]: https://github.com/grafana/mimir
+[6]: https://github.com/grafana/pyroscope
+[7]: https://github.com/minio/minio
+
+## Helpful Links
+
+- <https://grafana.com/docs/>
+- <https://github.com/grafana/agent-modules>
+- <https://github.com/docker/compose>
+- <https://grafana.com/docs/agent/latest/flow/reference/components/>
+- <https://github.com/k3d-io/k3d>
+- <https://github.com/k3s-io/k3s>
+- <https://github.com/grafana/grafana>
+- [Grafana Agent Configuration Generator](https://github.com/grafana/agent-configurator) a tool allows for easy configuration of Grafana Agents Flow system
+


### PR DESCRIPTION
🤖 Copy release notes from Draft

<details>
<summary> Full draft release notes for v0.1.0 </summary>
<blockquote>


# Release v0.1.0

A simple command to run Grafana LGTMP Stack in Docker or Kubernetes.

## What's Changed

- Improve sync rules to mimir cluster (#68)
- chore: rename from docker-compose.yaml to compose.yaml (#66)
- Docker Compose(traces): Enable caches (#56)
- Minio: Support  Minio Metrics V3 API (#52)
- Docker Compose: add --env-file support (#48)
- Take Grafana LGTMP Stack to the command line (#32)
- Showcase: agent module auto loading integrations (#19)
- Creating a registry proxy / pull-through registry (#18)

## 🚀 Features

- Add option to collect metrics (#58)
- Docker Compose(profiles): Profiles Ingestion via Labels (#51)
- Add pyroscope-mixin support (#50)
- Docker Compose(metrics): Metric Ingestion via Labels (#49)
- Docker Compose(logs): Log Ingestion via Labels (#47)
- Kubernetes(traces): add metrics\_generator (#39)
- Take Grafana LGTMP Stack to the command line (#25)
- Kubernetes: mimir-distributed for Metrics (#17)
- [Metrics] Add support deploy microservices mode in kubernetes (#7)
- Add support include feature in docker-compose v2.20 (#6)
- Add docker microservices mode metrics (#5)
- Add-microservices-mode-logs (#4)
- Add Read-Write mode - Metrics (#1)

## 🎯 Improvements

- Update draft release (#72)
- add common grafana and grafana-agent (#69)
- Metrics: Agent add cAdvisor integration (#64)
- Agents always enable metrics collection (#63)
- Separate dashboards rules and alerts provisioning (#62)
- Bump Pyroscope to 1.5.0 (#61)
- Kubernetes(LGTMP): Enable caches (#60)
- Kubernetes: charts config(loki mimir tempo pyroscope) in monolithic-mode  update (#59)
- Gateway(nginx): Defaulte env variable  values with entrypoint scripts (#57)
- Docker Compose(logs): Enable caches (#55)
- Docker Compose(metrics): Enable caches in monolithic-mode (#54)
- Avoid restarting grafana (#44)
- Bump grafana-agent to 0.40.2 (#42)
- Bump to Tempo 2.4.0 (#38)
- Bump Pyroscope to 1.4.0 (#34)
- update loki to 2.9.3 (#28)
- Mimirtool load rules instead of prometheus (#2)

## ⬆️ Dependencies

<details>
<summary>30 changes</summary>

- Bump Pyroscope to 1.5.0 (#61)
- Bump github.com/prometheus/common from 0.49.0 to 0.50.0 (#46)
- Move to https://github.com/qclaogui/agent-modules.git (#45)
- Bump to grafana 10.4.0 (#43)
- Bump grafana-agent to 0.40.2 (#42)
- Bump github.com/prometheus/common from 0.48.0 to 0.49.0 (#41)
- Bump github.com/stretchr/testify from 1.8.4 to 1.9.0 (#40)
- Bump to Tempo 2.4.0 (#38)
- Bump dagger.io/dagger from 0.9.10 to 0.9.11 (#37)
- Bump github.com/prometheus/common from 0.46.0 to 0.47.0 (#36)
- Bump dagger.io/dagger from 0.9.8 to 0.9.9 (#35)
- Bump Pyroscope to 1.4.0 (#34)
- update grafana to 10.3.1 (#31)
- grafana/loki:2.9.4 (#30)
- Bump dagger.io/dagger from 0.9.6 to 0.9.7 (#29)
- update loki to 2.9.3 (#28)
- Bump Mimir to 2.11.0 (#27)
- Bump Pyroscope to 1.3.0 (#26)
- Bump dagger.io/dagger from 0.9.5 to 0.9.6 (#24)
- Bump github.com/stretchr/testify from 1.8.3 to 1.8.4 (#22)
- Bump dagger.io/dagger from 0.9.1 to 0.9.4 (#21)
- Bump dagger.io/dagger from 0.9.0 to 0.9.1 (#15)
- Bump dagger.io/dagger from 0.8.8 to 0.9.0 (#14)
- Bump dagger.io/dagger from 0.8.7 to 0.8.8 (#13)
- Bump dagger.io/dagger from 0.8.5 to 0.8.7 (#12)
- Bump dagger.io/dagger from 0.8.4 to 0.8.5 (#11)
- Bump actions/checkout from 3 to 4 (#10)
- Bump dagger.io/dagger from 0.8.2 to 0.8.4 (#9)
- Bump dagger.io/dagger from 0.8.1 to 0.8.2 (#8)
- Bump dagger.io/dagger from 0.7.4 to 0.8.1 (#3)
</details>

## New Contributors


🎉 **Thanks to all contributors helping with this release!** 🎉
## Grafana LGTMP Stack default port-mapping

| Port-mapping | Component | Description |
| --- | --- | --- |
| `12345:12345`, `4317`, `4318`, `6831` | [Grafana Agent][1] | Eexpose `12345` port so we can directly access `grafana-agent` inside container |
| `33100:3100` | [Loki][2] | Expose `33100` port so we can directly access `loki` inside container |
| `3000:3000`, `6060` | [Grafana][3] | Expose `3000` port so we can directly access `grafana` inside container |
| `33200:3200`, `4317`, `4318` | [Tempo][4] | Expose `33200` port so we can directly access `tempo` inside container |
| `38080:8080` | [Mimir][5] | Expose `38080` port so we can directly access `mimir` inside container |
| `34040:4040` | [Pyroscope][6] | Expose `34040` port so we can directly access `pyroscope` inside container |
| `9001:9001`, `9000` | [Minio][7] | Expose `9001` port so we can access `minio` console with `MINIO_ROOT_USER=lgtmp`, `MINIO_ROOT_PASSWORD=supersecret` |

[1]: https://github.com/grafana/agent
[2]: https://github.com/grafana/loki
[3]: https://github.com/grafana/grafana
[4]: https://github.com/grafana/tempo
[5]: https://github.com/grafana/mimir
[6]: https://github.com/grafana/pyroscope
[7]: https://github.com/minio/minio

## Helpful Links

- <https://grafana.com/docs/>
- <https://github.com/grafana/agent-modules>
- <https://github.com/docker/compose>
- <https://grafana.com/docs/agent/latest/flow/reference/components/>
- <https://github.com/k3d-io/k3d>
- <https://github.com/k3s-io/k3s>
- <https://github.com/grafana/grafana>
- [Grafana Agent Configuration Generator](https://github.com/grafana/agent-configurator) a tool allows for easy configuration of Grafana Agents Flow system


</blockquote>
</details>
<br />

> Auto-generated by [Release Drafter GitHub Action][0]

[0]: https://github.com/qclaogui/codelab-monitoring/blob/main/.github/workflows/release-drafter.yml