### PR TITLE
Fix(compose): include services override not trigger

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,7 +5,7 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches:
       - main
-  workflow_dispatch: {}
+  workflow_dispatch: {} # Allow manual triggering
 
 jobs:
   update_release_draft:

--- a/docker-compose/microservices-mode/logs/compose.yaml
+++ b/docker-compose/microservices-mode/logs/compose.yaml
@@ -6,11 +6,14 @@ version: '3.9'
 
 # Note: 
 # include is available in Docker Compose version 2.20 and later, and Docker Desktop version 4.22 and later.
+# docs: https://docs.docker.com/compose/multiple-compose-files/include/#include-and-overrides
 include:
   - path: ../../common/compose-include/minio.yaml
   - path: ../../common/compose-include/memcached.yaml
   - path: ../../common/compose-include/mimir.yaml
-  - path: ../../common/compose-include/grafana-agent.yaml
+  - path:
+      - ../../common/compose-include/grafana-agent.yaml
+      - ./compose.override.yaml  # Microservices Mode services override
   - path: ../../common/compose-include/grafana.yaml
 
 # https://github.com/qclaogui/codelab-monitoring/blob/main/docker-compose/common/config/agent-flow/modules/docker/README.md

--- a/docker-compose/microservices-mode/profiles/compose.yaml
+++ b/docker-compose/microservices-mode/profiles/compose.yaml
@@ -6,11 +6,14 @@ version: '3.9'
 
 # Note: 
 # include is available in Docker Compose version 2.20 and later, and Docker Desktop version 4.22 and later.
+# docs: https://docs.docker.com/compose/multiple-compose-files/include/#include-and-overrides
 include:
   - path: ../../common/compose-include/minio.yaml
   - path: ../../common/compose-include/memcached.yaml
   - path: ../../common/compose-include/mimir.yaml
-  - path: ../../common/compose-include/grafana-agent.yaml
+  - path:
+      - ../../common/compose-include/grafana-agent.yaml
+      - ./compose.override.yaml  # Microservices Mode services override
   - path: ../../common/compose-include/grafana.yaml
 
 # https://github.com/qclaogui/codelab-monitoring/blob/main/docker-compose/common/config/agent-flow/modules/docker/README.md

--- a/docker-compose/microservices-mode/traces/compose.yaml
+++ b/docker-compose/microservices-mode/traces/compose.yaml
@@ -6,12 +6,15 @@ version: '3.9'
 
 # Note: 
 # include is available in Docker Compose version 2.20 and later, and Docker Desktop version 4.22 and later.
+# docs: https://docs.docker.com/compose/multiple-compose-files/include/#include-and-overrides
 include:
   - path: ../../common/compose-include/minio.yaml
   - path: ../../common/compose-include/memcached.yaml
   - path: ../../common/compose-include/mimir.yaml
   - path: ../../common/compose-include/loki.yaml
-  - path: ../../common/compose-include/grafana-agent.yaml
+  - path:
+      - ../../common/compose-include/grafana-agent.yaml
+      - ./compose.override.yaml  # Microservices Mode services override
   - path: ../../common/compose-include/grafana.yaml
 
 x-environment: &jaeger-environment

--- a/docker-compose/read-write-mode/logs/compose.yaml
+++ b/docker-compose/read-write-mode/logs/compose.yaml
@@ -6,11 +6,14 @@ version: '3.9'
 
 # Note: 
 # include is available in Docker Compose version 2.20 and later, and Docker Desktop version 4.22 and later.
+# docs: https://docs.docker.com/compose/multiple-compose-files/include/#include-and-overrides
 include:
   - path: ../../common/compose-include/minio.yaml
   - path: ../../common/compose-include/memcached.yaml
   - path: ../../common/compose-include/mimir.yaml
-  - path: ../../common/compose-include/grafana-agent.yaml
+  - path:
+      - ../../common/compose-include/grafana-agent.yaml
+      - ./compose.override.yaml  # Read-Write Mode services override
   - path: ../../common/compose-include/grafana.yaml
 
 x-labels: &loki-labels

--- a/examples/github-exporter/compose.yaml
+++ b/examples/github-exporter/compose.yaml
@@ -8,12 +8,18 @@
 
 # Note:
 # include is available in Docker Compose version 2.20 and later, and Docker Desktop version 4.22 and later.
+# docs: https://docs.docker.com/compose/multiple-compose-files/include/#include-and-overrides
 include:
 # - path: https://github.com/qclaogui/codelab-monitoring.git#main:docker-compose/monolithic-mode/all-in-one/compose.yaml  # All in one(Logs Traces Metrics Profiles)
 # - path: https://github.com/qclaogui/codelab-monitoring.git#main:docker-compose/monolithic-mode/metrics/compose.yaml     # Metrics
 - path: https://github.com/qclaogui/codelab-monitoring.git#main:docker-compose/monolithic-mode/logs/compose.yaml        # Metrics and Logs
 # - path: https://github.com/qclaogui/codelab-monitoring.git#main:docker-compose/monolithic-mode/traces/compose.yaml      # Metrics and Traces
 # - path: https://github.com/qclaogui/codelab-monitoring.git#main:docker-compose/monolithic-mode/profiles/compose.yaml    # Metrics and Profiles
+
+# Local
+# - path: ../../docker-compose/monolithic-mode/logs/compose.yaml
+# - path: ../../docker-compose/read-write-mode/logs/compose.yaml
+# - path: ../../docker-compose/microservices-mode/logs/compose.yaml
 
 services:
   github-exporter:


### PR DESCRIPTION
Fixed an issue where include service overrides was not triggered when external include occurred in read-write mode and microservice mode.

example `compose.yaml`:
```yaml
include:
- path: https://github.com/qclaogui/codelab-monitoring.git#main:docker-compose/read-write-mode/logs/compose.yaml

```
when run
```shell
COMPOSE_EXPERIMENTAL_GIT_REMOTE=true docker compose config
```
got 

```yaml
  ...

  grafana-agent:
    entrypoint:
      - /etc/agent-config/metrcs.river # metrcs.river is default
  ...
```

want 

```yaml
  ...

  grafana-agent:
    entrypoint:
      - /etc/agent-config/logs.river
  ...
```