### PR TITLE
[Embeded] Add an email testing server

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -75,6 +75,7 @@ footer: |
   | `38080:8080` | [Mimir][5] | Expose `38080` port so we can directly access `mimir` inside container |
   | `34040:4040` | [Pyroscope][6] | Expose `34040` port so we can directly access `pyroscope` inside container |
   | `9001:9001`, `9000` | [Minio][7] | Expose `9001` port so we can access `minio` console with `MINIO_ROOT_USER=lgtmp`, `MINIO_ROOT_PASSWORD=supersecret` |
+  | `39000:9000`, `2500`, `1100` | [Inbucket][8] | Expose `39000` port to use for the email testing server web interface. |
 
   [1]: https://github.com/grafana/agent
   [2]: https://github.com/grafana/loki
@@ -83,6 +84,7 @@ footer: |
   [5]: https://github.com/grafana/mimir
   [6]: https://github.com/grafana/pyroscope
   [7]: https://github.com/minio/minio
+  [8]: https://github.com/inbucket/inbucket
 
   ## Helpful Links
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Use "lgtmp [command] --help" for more information about a command.
 | `38080:8080` | [Mimir][5] | Expose `38080` port so we can directly access `mimir` inside container |
 | `34040:4040` | [Pyroscope][6] | Expose `34040` port so we can directly access `pyroscope` inside container |
 | `9001:9001`, `9000` | [Minio][7] | Expose `9001` port so we can access `minio` console with `MINIO_ROOT_USER=lgtmp`, `MINIO_ROOT_PASSWORD=supersecret` |
+| `39000:9000`, `2500`, `1100` | [Inbucket][8] | Expose `39000` port to use for the email testing server web interface. |
 
 [1]: https://github.com/grafana/agent
 [2]: https://github.com/grafana/loki
@@ -259,6 +260,7 @@ Use "lgtmp [command] --help" for more information about a command.
 [5]: https://github.com/grafana/mimir
 [6]: https://github.com/grafana/pyroscope
 [7]: https://github.com/minio/minio
+[8]: https://github.com/inbucket/inbucket
 
 ## Helpful Links
 

--- a/docker-compose/common/compose-include/grafana.yaml
+++ b/docker-compose/common/compose-include/grafana.yaml
@@ -1,4 +1,9 @@
 
+# Note: 
+# include is available in Docker Compose version 2.20 and later, and Docker Desktop version 4.22 and later.
+include:
+  - path: ./inbucket.yaml
+
 services:
   grafana:
     labels:
@@ -18,8 +23,6 @@ services:
       - ../../../monitoring-mixins/memcached-mixin/deploy/dashboards_out:/var/lib/grafana/dashboards/memcached-mixin
       # - ../../../monitoring-mixins/tempo-mixin/deploy/dashboards_out:/var/lib/grafana/dashboards/tempo-mixin
     environment:
-      - GF_LOG_LEVEL=warn
-      - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD:-admin_password}
-      - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor tracesEmbeddedFlameGraph traceqlSearch correlations metricsSummary traceToMetrics traceToProfiles
+      GF_FEATURE_TOGGLES_ENABLE: traceqlEditor tracesEmbeddedFlameGraph traceqlSearch correlations metricsSummary traceToMetrics traceToProfiles
     ports:
       - "3000:3000"

--- a/docker-compose/common/compose-include/inbucket.yaml
+++ b/docker-compose/common/compose-include/inbucket.yaml
@@ -1,0 +1,17 @@
+
+# Inbucket is an email testing service; it will accept email for any email
+# address and make it available to view without a password
+#
+# https://inbucket.org/packages/docker.html
+services:
+  inbucket:
+    labels:
+      metrics.agent.grafana.com/scrape: false
+    image: inbucket/inbucket:latest
+    ports:
+      - 2500 # SMTP
+      - "39000:9000" # HTTP
+      - 1100 # POP3
+    environment:
+      # https://github.com/inbucket/inbucket/blob/main/doc/config.md
+      INBUCKET_STORAGE_TYPE: ${INBUCKET_STORAGE_TYPE:-memory}

--- a/docker-compose/common/config/grafana/grafana.ini
+++ b/docker-compose/common/config/grafana/grafana.ini
@@ -30,3 +30,7 @@ disable_total_stats = false
 [dashboards]
 ;default_home_dashboard_path = /usr/share/grafana/public/dashboards/home.json
 default_home_dashboard_path = /var/lib/grafana/dashboards/minio-dashboard.json
+
+[smtp]
+enabled = true
+host = inbucket:2500

--- a/docker-compose/common/config/grafana/provisioning/alerting/cp-wangweifeng.yaml
+++ b/docker-compose/common/config/grafana/provisioning/alerting/cp-wangweifeng.yaml
@@ -16,6 +16,5 @@ contactPoints:
         type: email
         disableResolveMessage: false
         settings:
-          addresses: qclaogui@gmail.com
           singleEmail: false
-          message: my optional message to include
+          addresses: me@example.com;you@example.com

--- a/docker-compose/common/config/grafana/provisioning/alerting/np-wangweifeng.yaml
+++ b/docker-compose/common/config/grafana/provisioning/alerting/np-wangweifeng.yaml
@@ -53,5 +53,5 @@ policies:
     routes:
       - receiver: cp_wangweifeng
         object_matchers:
-          - ['namespace', '=', 'monitoring']
+          - ['namespace', '=', 'monitoring-system']
 

--- a/docker-compose/monolithic-mode/all-in-one/compose.yaml
+++ b/docker-compose/monolithic-mode/all-in-one/compose.yaml
@@ -10,6 +10,7 @@ include:
   - path: ../../common/compose-include/minio.yaml
   - path: ../../common/compose-include/memcached.yaml
   - path: ../../common/compose-include/load-rules-to-mimir.yaml
+  - path: ../../common/compose-include/inbucket.yaml
 
 # https://github.com/qclaogui/codelab-monitoring/blob/main/docker-compose/common/config/agent-flow/modules/docker/README.md
 x-labels: &profiles-labels
@@ -216,12 +217,12 @@ services:
       - ../../../monitoring-mixins/memcached-mixin/deploy/dashboards_out:/var/lib/grafana/dashboards/memcached-mixin
       # - ../../../monitoring-mixins/tempo-mixin/deploy/dashboards_out:/var/lib/grafana/dashboards/tempo-mixin
     environment:
-      - GF_LOG_LEVEL=warn
-      - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD:-admin_password}
-      - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor tracesEmbeddedFlameGraph traceqlSearch correlations metricsSummary traceToMetrics traceToProfiles
-      - GF_DIAGNOSTICS_PROFILING_ENABLED=true
-      - GF_DIAGNOSTICS_PROFILING_ADDR=0.0.0.0
-      - GF_DIAGNOSTICS_PROFILING_PORT=6060
+      GF_LOG_LEVEL: ${GF_LOG_LEVEL:-warn}
+      GF_SECURITY_ADMIN_PASSWORD: ${GF_SECURITY_ADMIN_PASSWORD:-admin}
+      GF_FEATURE_TOGGLES_ENABLE: traceqlEditor tracesEmbeddedFlameGraph traceqlSearch correlations metricsSummary traceToMetrics traceToProfiles
+      GF_DIAGNOSTICS_PROFILING_ENABLED: true
+      GF_DIAGNOSTICS_PROFILING_ADDR: 0.0.0.0
+      GF_DIAGNOSTICS_PROFILING_PORT: 6060
     ports:
       - "3000:3000"
 


### PR DESCRIPTION
Signed-off-by: Weifeng Wang <qclaogui@gmail.com>

https://github.com/inbucket/inbucket an email testing server to receive grafana email alerts. 

Emails sent with the local dev setup are not actually sent - rather, they are monitored, and you can view the emails that would have been sent from the web interface.

