### PR TITLE
[docker compose]: (WIP)Add compose publish (alpha) command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@
 
 include .bingo/Variables.mk
 
+# e.g. qclaogui/lgtmp:<version>-logs
+COMPOSE_REGISTRY ?= qclaogui/lgtmp
+
+
 ##@ Dependencies
 
 .PHONY: install-build-deps
@@ -30,6 +34,9 @@ fmt: ## Uses Grafana Agent to fmt the river config
 
 ##@ Docker compose
 
+.PHONY: publish
+publish: ## Publish compose files
+publish: publish-monolithic-mode-logs
 
 .PHONY: up-monolithic-mode-metrics
 up-monolithic-mode-metrics: ## Run monolithic-mode Mimir for metrics
@@ -56,6 +63,15 @@ up-monolithic-mode-logs: ## Run monolithic-mode Loki for logs
 	@$(call echo_info, "Go to http://localhost:3000/explore for the logs.")
 down-monolithic-mode-logs:
 	docker compose --project-name monolithic-logs down
+publish-monolithic-mode-logs:
+	$(info ******************** compose publish monolithic-mode logs ********************)
+	docker compose \
+		--project-name monolithic-logs \
+		--project-directory docker-compose/monolithic-mode/logs \
+		--file docker-compose/monolithic-mode/logs/compose.yaml \
+		--env-file docker-compose/common/config/.env \
+		alpha publish $(COMPOSE_REGISTRY):logs
+	@$(call echo_info, "Publish success.")
 
 .PHONY: up-monolithic-mode-traces
 up-monolithic-mode-traces: ## Run monolithic-mode Tempo for traces


### PR DESCRIPTION
#### What this PR does

Add docker compose publish (alpha) command. https://github.com/docker/compose/pull/10949

Before:

```yaml
include:
  - path: https://github.com/qclaogui/codelab-monitoring.git#main:docker-compose/monolithic-mode/logs/compose.yaml

...

```

Expected:

So we can simple use this published model:

```yaml
include:
  # docker:qclaogui/lgtmp:<version>-logs
  - docker:qclaogui/lgtmp:logs
  # - oci://ghcr.io/qclaogui/lgtmp:logs
  # - docker:qclaogui/lgtmp:all-in-one

...

```

Usage:

```shell
COMPOSE_EXPERIMENTAL_OCI_REMOTE=true docker compose up -d --remove-orphans
```

#### Which issue(s) this PR fixes or relates to

Fixes #67

#### CHECKLISTS

- [ ] publish monolithic-mode-metrics
- [ ] [publish monolithic-mode-logs](https://github.com/qclaogui/codelab-monitoring/pull/91/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R66)
- [ ] publish monolithic-mode-traces
- [ ] publish monolithic-mode-profiles
- [ ] publish monolithic-mode-all-in-one
