### PR TITLE
[Alloy Integrations] Add memcached Integration

### DIFF
--- a/docker-compose/common/compose-include/memcached.yaml
+++ b/docker-compose/common/compose-include/memcached.yaml
@@ -2,17 +2,19 @@
 services:
   memcached:
     labels:
-      - metrics.grafana.com/scrape=false
+      metrics.grafana.com/scrape: false
     image: ${MEMCACHED_IMAGE:-docker.io/memcached:1.6.24-alpine}
 
-  memcached-exporter:
-    labels:
-      - logs.grafana.com/scrape=false
-      - metrics.grafana.com/scrape=true
-      # - metrics.grafana.com/job=memcached
-      - metrics.grafana.com/port=9150
-      - metrics.grafana.com/interval=15s
-    image: ${MEMCACHED_EXPORTER_IMAGE:-prom/memcached-exporter:v0.14.2}
-    command:
-      - --memcached.address=memcached:11211
-      - --web.listen-address=0.0.0.0:9150
+  # Use Alloy prometheus.exporter.memcached component instead of memcached-exporter
+  # https://github.com/qclaogui/codelab-monitoring/pull/98
+  # memcached-exporter:
+  #   labels:
+  #     - logs.grafana.com/scrape=false
+  #     - metrics.grafana.com/scrape=false
+  #     # - metrics.grafana.com/job=memcached
+  #     - metrics.grafana.com/port=9150
+  #     - metrics.grafana.com/interval=15s
+  #   image: ${MEMCACHED_EXPORTER_IMAGE:-prom/memcached-exporter:v0.14.2}
+  #   command:
+  #     - --memcached.address=memcached:11211
+  #     - --web.listen-address=0.0.0.0:9150

--- a/docker-compose/common/config/alloy/all-in-one.alloy
+++ b/docker-compose/common/config/alloy/all-in-one.alloy
@@ -47,6 +47,13 @@ metrics.integrations_node_exporter "scrape" {
 	scrape_interval = "15s"
 }
 
+metrics.integrations_memcached "scrape" {
+	forward_to      = [provider.self_hosted.compose.metrics_receiver]
+	scrape_interval = "15s"
+
+	memcached_address = "memcached:11211"
+}
+
 /********************************************
  * Logs
  ********************************************/

--- a/docker-compose/common/config/alloy/logs.alloy
+++ b/docker-compose/common/config/alloy/logs.alloy
@@ -61,3 +61,10 @@ metrics.integrations_node_exporter "scrape" {
 	forward_to      = [provider.self_hosted.compose.metrics_receiver]
 	scrape_interval = "15s"
 }
+
+metrics.integrations_memcached "scrape" {
+	forward_to      = [provider.self_hosted.compose.metrics_receiver]
+	scrape_interval = "15s"
+
+	memcached_address = "memcached:11211"
+}

--- a/docker-compose/common/config/alloy/metrics.alloy
+++ b/docker-compose/common/config/alloy/metrics.alloy
@@ -43,3 +43,10 @@ metrics.integrations_node_exporter "scrape" {
 	forward_to      = [provider.self_hosted.compose.metrics_receiver]
 	scrape_interval = "15s"
 }
+
+metrics.integrations_memcached "scrape" {
+	forward_to      = [provider.self_hosted.compose.metrics_receiver]
+	scrape_interval = "15s"
+
+	memcached_address = "memcached:11211"
+}

--- a/docker-compose/common/config/alloy/modules/compose/metrics/integrations_memcached.alloy
+++ b/docker-compose/common/config/alloy/modules/compose/metrics/integrations_memcached.alloy
@@ -1,0 +1,118 @@
+/************************************************
+* Component: integrations_memcached
+*************************************************/
+
+declare "integrations_memcached" {
+
+	/********************************************
+	* ARGUMENTS
+	********************************************/
+	argument "forward_to" {
+		comment = "Must be a list(MetricssReceiver) where collected metrics should be forwarded to"
+	}
+
+	argument "memcached_address" {
+		optional = true
+		default  = "memcached:11211"
+	}
+
+	argument "memcached_timeout" {
+		optional = true
+		default  = "5s"
+	}
+
+	argument "cluster" {
+		optional = true
+		default  = "docker-compose"
+	}
+
+	argument "namespace" {
+		optional = true
+		default  = "monitoring-system"
+	}
+
+	argument "keep_metrics" {
+		optional = true
+		default  = "(.+)"
+	}
+
+	argument "scrape_interval" {
+		comment  = "How often to scrape metrics from the targets (default: 60s)"
+		optional = true
+		default  = "60s"
+	}
+
+	argument "scrape_timeout" {
+		comment  = "How long before a scrape times out (default: 10s)"
+		optional = true
+		default  = "10s"
+	}
+
+	/********************************************
+	* Integrations Memcached
+	********************************************/
+	prometheus.exporter.memcached "integrations_memcached" {
+		address = argument.memcached_address.value
+		timeout = argument.memcached_timeout.value
+	}
+	/********************************************
+	* Discovery Relabelings (pre-scrape)
+	********************************************/
+	discovery.relabel "integrations_memcached" {
+		targets = prometheus.exporter.memcached.integrations_memcached.targets
+
+		// set the cluster label
+		rule {
+			action       = "replace"
+			replacement  = argument.cluster.value
+			target_label = "cluster"
+		}
+
+		// set the namespace label
+		rule {
+			action       = "replace"
+			replacement  = argument.namespace.value
+			target_label = "namespace"
+		}
+
+		rule {
+			target_label = "job"
+			replacement  = "integrations/memcached"
+		}
+	}
+
+	/********************************************
+	* Prometheus Scrape Integrations Targets
+	********************************************/
+	prometheus.scrape "integrations_memcached" {
+		targets = concat(
+			discovery.relabel.integrations_memcached.output,
+		)
+
+		enable_protobuf_negotiation = true
+		scrape_classic_histograms   = true
+
+		scrape_interval = argument.scrape_interval.value
+		scrape_timeout  = argument.scrape_timeout.value
+
+		clustering {
+			enabled = true
+		}
+
+		forward_to = [prometheus.relabel.integrations_memcached.receiver]
+	}
+
+	/********************************************
+	* Prometheus Metric Relabelings (post-scrape)
+	********************************************/
+	prometheus.relabel "integrations_memcached" {
+		forward_to = argument.forward_to.value
+
+		// keep only metrics that match the keep_metrics regex
+		rule {
+			source_labels = ["__name__"]
+			regex         = argument.keep_metrics.value
+			action        = "keep"
+		}
+	}
+}

--- a/docker-compose/common/config/alloy/profiles.alloy
+++ b/docker-compose/common/config/alloy/profiles.alloy
@@ -57,3 +57,10 @@ metrics.integrations_node_exporter "scrape" {
 	forward_to      = [provider.self_hosted.compose.metrics_receiver]
 	scrape_interval = "15s"
 }
+
+metrics.integrations_memcached "scrape" {
+	forward_to      = [provider.self_hosted.compose.metrics_receiver]
+	scrape_interval = "15s"
+
+	memcached_address = "memcached:11211"
+}

--- a/docker-compose/common/config/alloy/traces.alloy
+++ b/docker-compose/common/config/alloy/traces.alloy
@@ -59,3 +59,10 @@ metrics.integrations_node_exporter "scrape" {
 	forward_to      = [provider.self_hosted.compose.metrics_receiver]
 	scrape_interval = "15s"
 }
+
+metrics.integrations_memcached "scrape" {
+	forward_to      = [provider.self_hosted.compose.metrics_receiver]
+	scrape_interval = "15s"
+
+	memcached_address = "memcached:11211"
+}

--- a/docker-compose/monolithic-mode/all-in-one/compose.yaml
+++ b/docker-compose/monolithic-mode/all-in-one/compose.yaml
@@ -40,9 +40,9 @@ services:
     volumes:
       - ../../common/config/alloy:/etc/alloy
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/lib/docker:/var/lib/docker:ro
       - /:/rootfs:ro
       - /sys:/sys:ro
-      - /var/lib/docker:/var/lib/docker:ro
     entrypoint:
       - /bin/alloy
       - run
@@ -55,6 +55,7 @@ services:
       - --storage.path=/var/lib/alloy/data
     environment:
       - ALLOY_CONFIG_FOLDER=/etc/alloy
+      - ALLOY_LOG_LEVEL=warn
     healthcheck:
       test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:12345/ready || exit 1" ]
       <<: *status-healthcheck


### PR DESCRIPTION
Signed-off-by: Weifeng Wang <qclaogui@gmail.com>

Use [`prometheus.exporter.memcached`](https://grafana.com/docs/alloy/latest/reference/components/prometheus.exporter.memcached/) component instead of `memcached-exporter`