### PR TITLE
[kubernetes] Logs from Kubernetes containers using the Kubernetes API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,7 @@ define config_changes_trigger_pod_restart
 	@kubectl rollout status -n gateway deployment/nginx --watch --timeout=600s
 	@echo "Provisioning Grafana dashboards Prometheus rules and alerts..."
 	@kubectl apply -f monitoring-mixins/k8s-all-in-one.yaml
-	kubectl rollout status -n monitoring-system daemonset/alloy --watch --timeout=600s
+	kubectl rollout status -n monitoring-system statefulset/alloy --watch --timeout=600s
 	@$(call echo_info, ${$@_MSG})
 endef
 

--- a/alloy-modules/compose/logs/keep-labels.alloy
+++ b/alloy-modules/compose/logs/keep-labels.alloy
@@ -20,17 +20,19 @@ declare "keep_labels" {
 		default  = [
 			"app",
 			"cluster",
-			"component",
+			"namespace",
+			"pod",
 			"container",
+			"component",
 			"env",
 			"job",
 			"level",
-			"namespace",
 			"region",
 			"service",
 			"squad",
 			"team",
 			"workload",
+			"source",
 		]
 	}
 
@@ -38,8 +40,6 @@ declare "keep_labels" {
 	* LOKI PROCESS
 	*****************************************************************/
 	loki.process "keep_labels" {
-		forward_to = argument.forward_to.value
-
 		/*
 		As all of the pod labels and annotations we transformed into labels in the previous relabelings to make
 		them available to the pipeline processing we need to ensure they are not automatically created in Loki.
@@ -50,6 +50,8 @@ declare "keep_labels" {
 		stage.label_keep {
 			values = argument.keep_labels.value
 		}
+
+		forward_to = argument.forward_to.value
 	}
 
 	/*****************************************************************

--- a/alloy-modules/compose/logs/labels-scrape.alloy
+++ b/alloy-modules/compose/logs/labels-scrape.alloy
@@ -52,9 +52,7 @@ declare "labels_scrape" {
 		default  = "(.*)"
 	}
 
-	/*****************************************************************
-	* Targets From Docker Discovery
-	*****************************************************************/
+	// find all containers
 	discovery.docker "dd_logs" {
 		host             = "unix:///var/run/docker.sock"
 		refresh_interval = "60s"
@@ -65,22 +63,10 @@ declare "labels_scrape" {
 		}
 	}
 
-	// get logs from discovery relabel dr_docker_logs below
-	loki.source.docker "lsd_docker_logs" {
-		forward_to = argument.forward_to.value
-
-		host          = "unix:///var/run/docker.sock"
-		targets       = discovery.relabel.dr_docker_logs.output
-		relabel_rules = discovery.relabel.dr_docker_logs.rules
-	}
-
-	discovery.relabel "dr_docker_logs" {
+	// filter logs by docker compose labels
+	discovery.relabel "label_logs_filter" {
 		targets = discovery.docker.dd_logs.targets
 
-		/****************************************************************************************************************
-		* Handle Discovers From Docker Engine Containers Targets to Keep or Drop
-		* https://grafana.com/docs/agent/latest/flow/reference/components/discovery.docker/#exported-fields
-		****************************************************************************************************************/
 		// allow resources to declare their metrics scraped or not
 		// Example Annotation:
 		//   logs.grafana.com/scrape: false
@@ -111,31 +97,6 @@ declare "labels_scrape" {
 				"__meta_docker_container_label_" + argument.__sd_label.value + "_tenant",
 			]
 			regex = "^(" + argument.tenant.value + ")$"
-		}
-
-		// make all labels on the pod available to the pipeline as labels(for loki process),
-		// they are omitted before write via label allow unless explicitly set
-		rule {
-			action = "labelmap"
-			regex  = "__meta_docker_container_label_(.+)"
-		}
-
-		/********************************************
-		* Handle Setting Common Labels
-		********************************************/
-
-		// set the cluster label
-		rule {
-			action       = "replace"
-			replacement  = argument.cluster.value
-			target_label = "cluster"
-		}
-
-		// set the namespace label
-		rule {
-			action       = "replace"
-			replacement  = argument.namespace.value
-			target_label = "namespace"
 		}
 
 		// set a default job label to be the namespace/service_name
@@ -193,6 +154,89 @@ declare "labels_scrape" {
 			regex        = "^(?:;*)?([^;]+).*$"
 			replacement  = "$1"
 			target_label = "app"
+		}
+
+		// make all labels on the pod available to the pipeline as labels(for loki process),
+		// they are omitted before write via label allow unless explicitly set
+		rule {
+			action = "labelmap"
+			regex  = "__meta_docker_container_label_(.+)"
+		}
+
+		/********************************************
+		* Handle Setting Common Labels
+		********************************************/
+		rule {
+			action       = "replace"
+			replacement  = argument.cluster.value
+			target_label = "cluster"
+		}
+
+		rule {
+			action       = "replace"
+			replacement  = argument.namespace.value
+			target_label = "namespace"
+		}
+
+		// set a source label
+		rule {
+			action       = "replace"
+			replacement  = "docker"
+			target_label = "source"
+		}
+
+		rule {
+			replacement  = "docker"
+			target_label = "tmp_container_runtime"
+		}
+	}
+
+	loki.source.docker "lsd_docker_logs" {
+		host          = "unix:///var/run/docker.sock"
+		targets       = discovery.relabel.label_logs_filter.output
+		relabel_rules = discovery.relabel.label_logs_filter.rules
+
+		forward_to = [loki.process.parse.receiver]
+	}
+
+	// parse the log based on the container runtime
+	loki.process "parse" {
+		forward_to = argument.forward_to.value
+		/*******************************************************************************
+		*                         Container Runtime Parsing
+		********************************************************************************/
+		// if the label tmp_container_runtime from above is containerd parse using cri
+		stage.match {
+			selector = "{tmp_container_runtime=\"containerd\"}"
+			// the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+			stage.cri { }
+
+			// Set the extract flags and stream values as labels
+			stage.labels {
+				values = {
+					flags  = "",
+					stream = "",
+				}
+			}
+		}
+
+		// if the label tmp_container_runtime from above is docker parse using docker
+		stage.match {
+			selector = "{tmp_container_runtime=\"docker\"}"
+			// the docker processing stage extracts the following k/v pairs: log, stream, time
+			stage.docker { }
+
+			// Set the extract stream value as a label
+			stage.labels {
+				values = {
+					stream = "",
+				}
+			}
+		}
+
+		// drop the temporary container runtime label as it is no longer needed
+		stage.label_drop {
+			values = ["tmp_container_runtime"]
 		}
 	}
 }

--- a/kubernetes/common/alloy/configs/kubernetes/logs/annotations-scrape.alloy
+++ b/kubernetes/common/alloy/configs/kubernetes/logs/annotations-scrape.alloy
@@ -34,10 +34,6 @@ declare "annotations_scrape" {
 		optional = true
 	}
 
-	/*
-    Hidden Arguments
-    These arguments are used to set reusable variables to avoid repeating logic
-  */
 	argument "__sd_annotation" {
 		optional = true
 		comment  = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
@@ -45,7 +41,7 @@ declare "annotations_scrape" {
 	}
 
 	// find all pods
-	discovery.kubernetes "log_annotations" {
+	discovery.kubernetes "annotation_logs" {
 		role = "pod"
 
 		namespaces {
@@ -53,9 +49,9 @@ declare "annotations_scrape" {
 		}
 	}
 
-	// apply relabelings
-	discovery.relabel "log_annotations" {
-		targets = discovery.kubernetes.log_annotations.targets
+	// filter logs by kubernetes annotations
+	discovery.relabel "annotation_logs_filter" {
+		targets = discovery.kubernetes.annotation_logs.targets
 
 		// allow pods to declare their logs to be ingested or not, the default is true
 		//   i.e. logs.grafana.com/ingest: false
@@ -176,29 +172,19 @@ declare "annotations_scrape" {
 			replacement  = "$2/$1"
 			target_label = "job"
 		}
-	}
 
-	discovery.relabel "worker_logs" {
-		targets = discovery.relabel.log_annotations.output
-
-		// set the __path__, this is automatically translated as a label of filename (which should be dropped or normalized)
-		// DO NOT delete this line as it is needed to tail the pod logs on the node
+		// make all labels on the pod available to the pipeline as labels,
+		// they are omitted before write via labelallow unless explicitly set
 		rule {
-			action        = "replace"
-			separator     = "/"
-			source_labels = [
-				"__meta_kubernetes_pod_uid",
-				"__meta_kubernetes_pod_container_name",
-			]
-			replacement  = "/var/log/pods/*$1/*.log"
-			target_label = "__path__"
+			action = "labelmap"
+			regex  = "__meta_kubernetes_pod_label_(.+)"
 		}
 
-		// set the __host__
+		// make all annotations on the pod available to the pipeline as labels,
+		// they are omitted before write via labelallow unless explicitly set
 		rule {
-			action        = "replace"
-			source_labels = ["__meta_kubernetes_pod_node_name"]
-			target_label  = "__host__"
+			action = "labelmap"
+			regex  = "__meta_kubernetes_pod_annotation_(.+)"
 		}
 
 		// as a result of kubernetes service discovery for pods, all of the meta data information is exposed in labels
@@ -215,30 +201,10 @@ declare "annotations_scrape" {
 			replacement   = "$1"
 			target_label  = "tmp_container_runtime"
 		}
-
-		// make all labels on the pod available to the pipeline as labels,
-		// they are omitted before write via labelallow unless explicitly set
-		rule {
-			action = "labelmap"
-			regex  = "__meta_kubernetes_pod_label_(.+)"
-		}
-
-		// make all annotations on the pod available to the pipeline as labels,
-		// they are omitted before write via labelallow unless explicitly set
-		rule {
-			action = "labelmap"
-			regex  = "__meta_kubernetes_pod_annotation_(.+)"
-		}
 	}
 
-	// find eligible files on the worker
-	local.file_match "pods" {
-		path_targets = discovery.relabel.worker_logs.output
-	}
-
-	// tail the files
-	loki.source.file "pods" {
-		targets    = local.file_match.pods.targets
+	loki.source.kubernetes "lsd_kubernetes_logs" {
+		targets    = discovery.relabel.annotation_logs_filter.output
 		forward_to = [loki.process.parse.receiver]
 	}
 
@@ -246,8 +212,8 @@ declare "annotations_scrape" {
 	loki.process "parse" {
 		forward_to = argument.forward_to.value
 		/*******************************************************************************
-     *                         Container Runtime Parsing
-     ********************************************************************************/
+		*                         Container Runtime Parsing
+		********************************************************************************/
 		// if the label tmp_container_runtime from above is containerd parse using cri
 		stage.match {
 			selector = "{tmp_container_runtime=\"containerd\"}"

--- a/kubernetes/common/alloy/manifests/k8s-all-in-one.yaml
+++ b/kubernetes/common/alloy/manifests/k8s-all-in-one.yaml
@@ -196,15 +196,14 @@ data:
     to look for targets in (default: [\\\"kube-system\\\"] is all namespaces)\"\n\t\toptional
     = true\n\t}\n\n\targument \"annotation_prefix\" {\n\t\tcomment  = \"The annotation_prefix
     to use (default: logs.grafana.com)\"\n\t\tdefault  = \"logs.grafana.com\"\n\t\toptional
-    = true\n\t}\n\n\t/*\n    Hidden Arguments\n    These arguments are used to set
-    reusable variables to avoid repeating logic\n  */\n\targument \"__sd_annotation\"
-    {\n\t\toptional = true\n\t\tcomment  = \"The logic is used to transform the annotation
-    argument into a valid label name by removing unsupported characters.\"\n\t\tdefault
-    \ = replace(replace(replace(coalesce(argument.annotation_prefix.value, \"logs.grafana.com\"),
-    \".\", \"_\"), \"/\", \"_\"), \"-\", \"_\")\n\t}\n\n\t// find all pods\n\tdiscovery.kubernetes
-    \"log_annotations\" {\n\t\trole = \"pod\"\n\n\t\tnamespaces {\n\t\t\tnames = coalesce(argument.namespaces.value,
-    [])\n\t\t}\n\t}\n\n\t// apply relabelings\n\tdiscovery.relabel \"log_annotations\"
-    {\n\t\ttargets = discovery.kubernetes.log_annotations.targets\n\n\t\t// allow
+    = true\n\t}\n\n\targument \"__sd_annotation\" {\n\t\toptional = true\n\t\tcomment
+    \ = \"The logic is used to transform the annotation argument into a valid label
+    name by removing unsupported characters.\"\n\t\tdefault  = replace(replace(replace(coalesce(argument.annotation_prefix.value,
+    \"logs.grafana.com\"), \".\", \"_\"), \"/\", \"_\"), \"-\", \"_\")\n\t}\n\n\t//
+    find all pods\n\tdiscovery.kubernetes \"annotation_logs\" {\n\t\trole = \"pod\"\n\n\t\tnamespaces
+    {\n\t\t\tnames = coalesce(argument.namespaces.value, [])\n\t\t}\n\t}\n\n\t// filter
+    logs by kubernetes annotations\n\tdiscovery.relabel \"annotation_logs_filter\"
+    {\n\t\ttargets = discovery.kubernetes.annotation_logs.targets\n\n\t\t// allow
     pods to declare their logs to be ingested or not, the default is true\n\t\t//
     \  i.e. logs.grafana.com/ingest: false\n\t\trule {\n\t\t\taction        = \"keep\"\n\t\t\tsource_labels
     = [\n\t\t\t\t\"__meta_kubernetes_pod_annotation_\" + argument.__sd_annotation.value
@@ -242,15 +241,12 @@ data:
     set the job label to be namespace / friendly pod name\n\t\trule {\n\t\t\taction
     \       = \"replace\"\n\t\t\tsource_labels = [\n\t\t\t\t\"workload\",\n\t\t\t\t\"__meta_kubernetes_namespace\",\n\t\t\t]\n\t\t\tregex
     \       = \".+\\\\/(.+);(.+)\"\n\t\t\treplacement  = \"$2/$1\"\n\t\t\ttarget_label
-    = \"job\"\n\t\t}\n\t}\n\n\tdiscovery.relabel \"worker_logs\" {\n\t\ttargets =
-    discovery.relabel.log_annotations.output\n\n\t\t// set the __path__, this is automatically
-    translated as a label of filename (which should be dropped or normalized)\n\t\t//
-    DO NOT delete this line as it is needed to tail the pod logs on the node\n\t\trule
-    {\n\t\t\taction        = \"replace\"\n\t\t\tseparator     = \"/\"\n\t\t\tsource_labels
-    = [\n\t\t\t\t\"__meta_kubernetes_pod_uid\",\n\t\t\t\t\"__meta_kubernetes_pod_container_name\",\n\t\t\t]\n\t\t\treplacement
-    \ = \"/var/log/pods/*$1/*.log\"\n\t\t\ttarget_label = \"__path__\"\n\t\t}\n\n\t\t//
-    set the __host__\n\t\trule {\n\t\t\taction        = \"replace\"\n\t\t\tsource_labels
-    = [\"__meta_kubernetes_pod_node_name\"]\n\t\t\ttarget_label  = \"__host__\"\n\t\t}\n\n\t\t//
+    = \"job\"\n\t\t}\n\n\t\t// make all labels on the pod available to the pipeline
+    as labels,\n\t\t// they are omitted before write via labelallow unless explicitly
+    set\n\t\trule {\n\t\t\taction = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_label_(.+)\"\n\t\t}\n\n\t\t//
+    make all annotations on the pod available to the pipeline as labels,\n\t\t// they
+    are omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
+    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_annotation_(.+)\"\n\t\t}\n\n\t\t//
     as a result of kubernetes service discovery for pods, all of the meta data information
     is exposed in labels\n\t\t// __meta_kubernetes_pod_*, including __meta_kubernetes_pod_container_id
     which can be used to determine what\n\t\t// the pods container runtime is, docker
@@ -261,19 +257,11 @@ data:
     automatically determined, then drop the label from the loki.process stage.\n\t\t//
     set the container runtime as a label\n\t\trule {\n\t\t\taction        = \"replace\"\n\t\t\tsource_labels
     = [\"__meta_kubernetes_pod_container_id\"]\n\t\t\tregex         = \"^(\\\\w+):\\\\/\\\\/.+$\"\n\t\t\treplacement
-    \  = \"$1\"\n\t\t\ttarget_label  = \"tmp_container_runtime\"\n\t\t}\n\n\t\t//
-    make all labels on the pod available to the pipeline as labels,\n\t\t// they are
-    omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
-    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_label_(.+)\"\n\t\t}\n\n\t\t//
-    make all annotations on the pod available to the pipeline as labels,\n\t\t// they
-    are omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
-    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_annotation_(.+)\"\n\t\t}\n\t}\n\n\t//
-    find eligible files on the worker\n\tlocal.file_match \"pods\" {\n\t\tpath_targets
-    = discovery.relabel.worker_logs.output\n\t}\n\n\t// tail the files\n\tloki.source.file
-    \"pods\" {\n\t\ttargets    = local.file_match.pods.targets\n\t\tforward_to = [loki.process.parse.receiver]\n\t}\n\n\t//
-    parse the log based on the container runtime\n\tloki.process \"parse\" {\n\t\tforward_to
-    = argument.forward_to.value\n\t\t/*******************************************************************************\n
-    \    *                         Container Runtime Parsing\n     ********************************************************************************/\n\t\t//
+    \  = \"$1\"\n\t\t\ttarget_label  = \"tmp_container_runtime\"\n\t\t}\n\t}\n\n\tloki.source.kubernetes
+    \"lsd_kubernetes_logs\" {\n\t\ttargets    = discovery.relabel.annotation_logs_filter.output\n\t\tforward_to
+    = [loki.process.parse.receiver]\n\t}\n\n\t// parse the log based on the container
+    runtime\n\tloki.process \"parse\" {\n\t\tforward_to = argument.forward_to.value\n\t\t/*******************************************************************************\n\t\t*
+    \                        Container Runtime Parsing\n\t\t********************************************************************************/\n\t\t//
     if the label tmp_container_runtime from above is containerd parse using cri\n\t\tstage.match
     {\n\t\t\tselector = \"{tmp_container_runtime=\\\"containerd\\\"}\"\n\t\t\t// the
     cri processing stage extracts the following k/v pairs: log, stream, time, flags\n\t\t\tstage.cri
@@ -309,7 +297,7 @@ data:
     \"receiver\" {\n\t\tvalue = loki.process.keep_labels.receiver\n\t}\n}\n"
 kind: ConfigMap
 metadata:
-  name: alloy-modules-kubernetes-logs-dfhkhc94gt
+  name: alloy-modules-kubernetes-logs-d7c756mt2f
   namespace: monitoring-system
 ---
 apiVersion: v1
@@ -763,7 +751,7 @@ spec:
   type: ClusterIP
 ---
 apiVersion: apps/v1
-kind: DaemonSet
+kind: StatefulSet
 metadata:
   labels:
     app.kubernetes.io/instance: alloy
@@ -775,10 +763,16 @@ metadata:
   namespace: monitoring-system
 spec:
   minReadySeconds: 10
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  podManagementPolicy: Parallel
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: alloy
       app.kubernetes.io/name: alloy
+  serviceName: alloy
   template:
     metadata:
       annotations:
@@ -846,9 +840,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/alloy
           name: config
-        - mountPath: /var/log
-          name: varlog
-          readOnly: true
         - mountPath: /etc/alloy/modules/kubernetes/metrics
           name: modules-kubernetes-metrics
         - mountPath: /etc/alloy/modules/kubernetes/integrations
@@ -867,9 +858,6 @@ spec:
       - configMap:
           name: alloy-config-ftt29f8k85
         name: config
-      - hostPath:
-          path: /var/log
-        name: varlog
       - configMap:
           name: alloy-modules-kubernetes-metrics-tf9cd8b6bg
         name: modules-kubernetes-metrics
@@ -877,7 +865,7 @@ spec:
           name: alloy-modules-kubernetes-integrations-9k86fb8hkg
         name: modules-kubernetes-integrations
       - configMap:
-          name: alloy-modules-kubernetes-logs-dfhkhc94gt
+          name: alloy-modules-kubernetes-logs-d7c756mt2f
         name: modules-kubernetes-logs
       - configMap:
           name: alloy-modules-kubernetes-traces-8mgm8th9m5
@@ -885,11 +873,6 @@ spec:
       - configMap:
           name: alloy-modules-kubernetes-profiles-66c27bc84g
         name: modules-kubernetes-profiles
-  updateStrategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 2
-    type: RollingUpdate
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/kubernetes/common/alloy/values-k3d-k3s.yaml
+++ b/kubernetes/common/alloy/values-k3d-k3s.yaml
@@ -17,8 +17,7 @@ alloy:
       name: alloy-env
       optional: true
   mounts:
-    # -- Mount /var/log from the host into the container for log collection.
-    varlog: true
+    # TODO(qc) remove this by Alloy import.git
     extra:
     - name: modules-kubernetes-metrics
       mountPath: /etc/alloy/modules/kubernetes/metrics
@@ -58,7 +57,9 @@ ingress:
   - alloy.localhost
 
 controller:
-  type: daemonset
+  type: statefulset
+  enableStatefulSetAutoDeletePVC: true
+  replicas: 1
   volumes:
     extra:
     - name: modules-kubernetes-metrics
@@ -88,10 +89,5 @@ controller:
     profiles.grafana.com/cpu.port_name: "http-metrics"
     profiles.grafana.com/goroutine.scrape: "false"
     profiles.grafana.com/goroutine.port_name: "http-metrics"
-  updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 2
-      maxSurge: 0
   nodeSelector:
     kubernetes.io/os: linux

--- a/kubernetes/microservices-mode/logs/k8s-all-in-one.yaml
+++ b/kubernetes/microservices-mode/logs/k8s-all-in-one.yaml
@@ -411,15 +411,14 @@ data:
     to look for targets in (default: [\\\"kube-system\\\"] is all namespaces)\"\n\t\toptional
     = true\n\t}\n\n\targument \"annotation_prefix\" {\n\t\tcomment  = \"The annotation_prefix
     to use (default: logs.grafana.com)\"\n\t\tdefault  = \"logs.grafana.com\"\n\t\toptional
-    = true\n\t}\n\n\t/*\n    Hidden Arguments\n    These arguments are used to set
-    reusable variables to avoid repeating logic\n  */\n\targument \"__sd_annotation\"
-    {\n\t\toptional = true\n\t\tcomment  = \"The logic is used to transform the annotation
-    argument into a valid label name by removing unsupported characters.\"\n\t\tdefault
-    \ = replace(replace(replace(coalesce(argument.annotation_prefix.value, \"logs.grafana.com\"),
-    \".\", \"_\"), \"/\", \"_\"), \"-\", \"_\")\n\t}\n\n\t// find all pods\n\tdiscovery.kubernetes
-    \"log_annotations\" {\n\t\trole = \"pod\"\n\n\t\tnamespaces {\n\t\t\tnames = coalesce(argument.namespaces.value,
-    [])\n\t\t}\n\t}\n\n\t// apply relabelings\n\tdiscovery.relabel \"log_annotations\"
-    {\n\t\ttargets = discovery.kubernetes.log_annotations.targets\n\n\t\t// allow
+    = true\n\t}\n\n\targument \"__sd_annotation\" {\n\t\toptional = true\n\t\tcomment
+    \ = \"The logic is used to transform the annotation argument into a valid label
+    name by removing unsupported characters.\"\n\t\tdefault  = replace(replace(replace(coalesce(argument.annotation_prefix.value,
+    \"logs.grafana.com\"), \".\", \"_\"), \"/\", \"_\"), \"-\", \"_\")\n\t}\n\n\t//
+    find all pods\n\tdiscovery.kubernetes \"annotation_logs\" {\n\t\trole = \"pod\"\n\n\t\tnamespaces
+    {\n\t\t\tnames = coalesce(argument.namespaces.value, [])\n\t\t}\n\t}\n\n\t// filter
+    logs by kubernetes annotations\n\tdiscovery.relabel \"annotation_logs_filter\"
+    {\n\t\ttargets = discovery.kubernetes.annotation_logs.targets\n\n\t\t// allow
     pods to declare their logs to be ingested or not, the default is true\n\t\t//
     \  i.e. logs.grafana.com/ingest: false\n\t\trule {\n\t\t\taction        = \"keep\"\n\t\t\tsource_labels
     = [\n\t\t\t\t\"__meta_kubernetes_pod_annotation_\" + argument.__sd_annotation.value
@@ -457,15 +456,12 @@ data:
     set the job label to be namespace / friendly pod name\n\t\trule {\n\t\t\taction
     \       = \"replace\"\n\t\t\tsource_labels = [\n\t\t\t\t\"workload\",\n\t\t\t\t\"__meta_kubernetes_namespace\",\n\t\t\t]\n\t\t\tregex
     \       = \".+\\\\/(.+);(.+)\"\n\t\t\treplacement  = \"$2/$1\"\n\t\t\ttarget_label
-    = \"job\"\n\t\t}\n\t}\n\n\tdiscovery.relabel \"worker_logs\" {\n\t\ttargets =
-    discovery.relabel.log_annotations.output\n\n\t\t// set the __path__, this is automatically
-    translated as a label of filename (which should be dropped or normalized)\n\t\t//
-    DO NOT delete this line as it is needed to tail the pod logs on the node\n\t\trule
-    {\n\t\t\taction        = \"replace\"\n\t\t\tseparator     = \"/\"\n\t\t\tsource_labels
-    = [\n\t\t\t\t\"__meta_kubernetes_pod_uid\",\n\t\t\t\t\"__meta_kubernetes_pod_container_name\",\n\t\t\t]\n\t\t\treplacement
-    \ = \"/var/log/pods/*$1/*.log\"\n\t\t\ttarget_label = \"__path__\"\n\t\t}\n\n\t\t//
-    set the __host__\n\t\trule {\n\t\t\taction        = \"replace\"\n\t\t\tsource_labels
-    = [\"__meta_kubernetes_pod_node_name\"]\n\t\t\ttarget_label  = \"__host__\"\n\t\t}\n\n\t\t//
+    = \"job\"\n\t\t}\n\n\t\t// make all labels on the pod available to the pipeline
+    as labels,\n\t\t// they are omitted before write via labelallow unless explicitly
+    set\n\t\trule {\n\t\t\taction = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_label_(.+)\"\n\t\t}\n\n\t\t//
+    make all annotations on the pod available to the pipeline as labels,\n\t\t// they
+    are omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
+    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_annotation_(.+)\"\n\t\t}\n\n\t\t//
     as a result of kubernetes service discovery for pods, all of the meta data information
     is exposed in labels\n\t\t// __meta_kubernetes_pod_*, including __meta_kubernetes_pod_container_id
     which can be used to determine what\n\t\t// the pods container runtime is, docker
@@ -476,19 +472,11 @@ data:
     automatically determined, then drop the label from the loki.process stage.\n\t\t//
     set the container runtime as a label\n\t\trule {\n\t\t\taction        = \"replace\"\n\t\t\tsource_labels
     = [\"__meta_kubernetes_pod_container_id\"]\n\t\t\tregex         = \"^(\\\\w+):\\\\/\\\\/.+$\"\n\t\t\treplacement
-    \  = \"$1\"\n\t\t\ttarget_label  = \"tmp_container_runtime\"\n\t\t}\n\n\t\t//
-    make all labels on the pod available to the pipeline as labels,\n\t\t// they are
-    omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
-    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_label_(.+)\"\n\t\t}\n\n\t\t//
-    make all annotations on the pod available to the pipeline as labels,\n\t\t// they
-    are omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
-    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_annotation_(.+)\"\n\t\t}\n\t}\n\n\t//
-    find eligible files on the worker\n\tlocal.file_match \"pods\" {\n\t\tpath_targets
-    = discovery.relabel.worker_logs.output\n\t}\n\n\t// tail the files\n\tloki.source.file
-    \"pods\" {\n\t\ttargets    = local.file_match.pods.targets\n\t\tforward_to = [loki.process.parse.receiver]\n\t}\n\n\t//
-    parse the log based on the container runtime\n\tloki.process \"parse\" {\n\t\tforward_to
-    = argument.forward_to.value\n\t\t/*******************************************************************************\n
-    \    *                         Container Runtime Parsing\n     ********************************************************************************/\n\t\t//
+    \  = \"$1\"\n\t\t\ttarget_label  = \"tmp_container_runtime\"\n\t\t}\n\t}\n\n\tloki.source.kubernetes
+    \"lsd_kubernetes_logs\" {\n\t\ttargets    = discovery.relabel.annotation_logs_filter.output\n\t\tforward_to
+    = [loki.process.parse.receiver]\n\t}\n\n\t// parse the log based on the container
+    runtime\n\tloki.process \"parse\" {\n\t\tforward_to = argument.forward_to.value\n\t\t/*******************************************************************************\n\t\t*
+    \                        Container Runtime Parsing\n\t\t********************************************************************************/\n\t\t//
     if the label tmp_container_runtime from above is containerd parse using cri\n\t\tstage.match
     {\n\t\t\tselector = \"{tmp_container_runtime=\\\"containerd\\\"}\"\n\t\t\t// the
     cri processing stage extracts the following k/v pairs: log, stream, time, flags\n\t\t\tstage.cri
@@ -524,7 +512,7 @@ data:
     \"receiver\" {\n\t\tvalue = loki.process.keep_labels.receiver\n\t}\n}\n"
 kind: ConfigMap
 metadata:
-  name: alloy-modules-kubernetes-logs-dfhkhc94gt
+  name: alloy-modules-kubernetes-logs-d7c756mt2f
   namespace: monitoring-system
 ---
 apiVersion: v1
@@ -2800,73 +2788,8 @@ spec:
       - emptyDir: {}
         name: data
 ---
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  labels:
-    app.kubernetes.io/component: distributor
-    app.kubernetes.io/instance: loki-distributed
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: loki
-    app.kubernetes.io/version: 3.0.0
-    helm.sh/chart: loki-6.1.0
-  name: loki-distributed-distributor
-  namespace: logging-system
-spec:
-  maxUnavailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/component: distributor
-      app.kubernetes.io/instance: loki-distributed
-      app.kubernetes.io/name: loki
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  labels:
-    app.kubernetes.io/component: ingester
-    app.kubernetes.io/instance: loki-distributed
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: loki
-    app.kubernetes.io/version: 3.0.0
-    helm.sh/chart: loki-6.1.0
-  name: loki-distributed-ingester
-  namespace: logging-system
-spec:
-  maxUnavailable: 1
-  selector:
-    matchExpressions:
-    - key: rollout-group
-      operator: NotIn
-      values:
-      - ingester
-    matchLabels:
-      app.kubernetes.io/component: ingester
-      app.kubernetes.io/instance: loki-distributed
-      app.kubernetes.io/name: loki
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  labels:
-    app.kubernetes.io/component: querier
-    app.kubernetes.io/instance: loki-distributed
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: loki
-    app.kubernetes.io/version: 3.0.0
-    helm.sh/chart: loki-6.1.0
-  name: loki-distributed-querier
-  namespace: logging-system
-spec:
-  maxUnavailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/component: querier
-      app.kubernetes.io/instance: loki-distributed
-      app.kubernetes.io/name: loki
----
 apiVersion: apps/v1
-kind: DaemonSet
+kind: StatefulSet
 metadata:
   labels:
     app.kubernetes.io/instance: alloy
@@ -2878,10 +2801,16 @@ metadata:
   namespace: monitoring-system
 spec:
   minReadySeconds: 10
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  podManagementPolicy: Parallel
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: alloy
       app.kubernetes.io/name: alloy
+  serviceName: alloy
   template:
     metadata:
       annotations:
@@ -2949,9 +2878,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/alloy
           name: config
-        - mountPath: /var/log
-          name: varlog
-          readOnly: true
         - mountPath: /etc/alloy/modules/kubernetes/metrics
           name: modules-kubernetes-metrics
         - mountPath: /etc/alloy/modules/kubernetes/integrations
@@ -2970,9 +2896,6 @@ spec:
       - configMap:
           name: alloy-config-8t9d8htff7
         name: config
-      - hostPath:
-          path: /var/log
-        name: varlog
       - configMap:
           name: alloy-modules-kubernetes-metrics-tf9cd8b6bg
         name: modules-kubernetes-metrics
@@ -2980,7 +2903,7 @@ spec:
           name: alloy-modules-kubernetes-integrations-9k86fb8hkg
         name: modules-kubernetes-integrations
       - configMap:
-          name: alloy-modules-kubernetes-logs-dfhkhc94gt
+          name: alloy-modules-kubernetes-logs-d7c756mt2f
         name: modules-kubernetes-logs
       - configMap:
           name: alloy-modules-kubernetes-traces-8mgm8th9m5
@@ -2988,11 +2911,71 @@ spec:
       - configMap:
           name: alloy-modules-kubernetes-profiles-66c27bc84g
         name: modules-kubernetes-profiles
-  updateStrategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 2
-    type: RollingUpdate
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/instance: loki-distributed
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/version: 3.0.0
+    helm.sh/chart: loki-6.1.0
+  name: loki-distributed-distributor
+  namespace: logging-system
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: distributor
+      app.kubernetes.io/instance: loki-distributed
+      app.kubernetes.io/name: loki
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: loki-distributed
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/version: 3.0.0
+    helm.sh/chart: loki-6.1.0
+  name: loki-distributed-ingester
+  namespace: logging-system
+spec:
+  maxUnavailable: 1
+  selector:
+    matchExpressions:
+    - key: rollout-group
+      operator: NotIn
+      values:
+      - ingester
+    matchLabels:
+      app.kubernetes.io/component: ingester
+      app.kubernetes.io/instance: loki-distributed
+      app.kubernetes.io/name: loki
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/instance: loki-distributed
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/version: 3.0.0
+    helm.sh/chart: loki-6.1.0
+  name: loki-distributed-querier
+  namespace: logging-system
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: querier
+      app.kubernetes.io/instance: loki-distributed
+      app.kubernetes.io/name: loki
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/kubernetes/microservices-mode/metrics/k8s-all-in-one.yaml
+++ b/kubernetes/microservices-mode/metrics/k8s-all-in-one.yaml
@@ -234,15 +234,14 @@ data:
     to look for targets in (default: [\\\"kube-system\\\"] is all namespaces)\"\n\t\toptional
     = true\n\t}\n\n\targument \"annotation_prefix\" {\n\t\tcomment  = \"The annotation_prefix
     to use (default: logs.grafana.com)\"\n\t\tdefault  = \"logs.grafana.com\"\n\t\toptional
-    = true\n\t}\n\n\t/*\n    Hidden Arguments\n    These arguments are used to set
-    reusable variables to avoid repeating logic\n  */\n\targument \"__sd_annotation\"
-    {\n\t\toptional = true\n\t\tcomment  = \"The logic is used to transform the annotation
-    argument into a valid label name by removing unsupported characters.\"\n\t\tdefault
-    \ = replace(replace(replace(coalesce(argument.annotation_prefix.value, \"logs.grafana.com\"),
-    \".\", \"_\"), \"/\", \"_\"), \"-\", \"_\")\n\t}\n\n\t// find all pods\n\tdiscovery.kubernetes
-    \"log_annotations\" {\n\t\trole = \"pod\"\n\n\t\tnamespaces {\n\t\t\tnames = coalesce(argument.namespaces.value,
-    [])\n\t\t}\n\t}\n\n\t// apply relabelings\n\tdiscovery.relabel \"log_annotations\"
-    {\n\t\ttargets = discovery.kubernetes.log_annotations.targets\n\n\t\t// allow
+    = true\n\t}\n\n\targument \"__sd_annotation\" {\n\t\toptional = true\n\t\tcomment
+    \ = \"The logic is used to transform the annotation argument into a valid label
+    name by removing unsupported characters.\"\n\t\tdefault  = replace(replace(replace(coalesce(argument.annotation_prefix.value,
+    \"logs.grafana.com\"), \".\", \"_\"), \"/\", \"_\"), \"-\", \"_\")\n\t}\n\n\t//
+    find all pods\n\tdiscovery.kubernetes \"annotation_logs\" {\n\t\trole = \"pod\"\n\n\t\tnamespaces
+    {\n\t\t\tnames = coalesce(argument.namespaces.value, [])\n\t\t}\n\t}\n\n\t// filter
+    logs by kubernetes annotations\n\tdiscovery.relabel \"annotation_logs_filter\"
+    {\n\t\ttargets = discovery.kubernetes.annotation_logs.targets\n\n\t\t// allow
     pods to declare their logs to be ingested or not, the default is true\n\t\t//
     \  i.e. logs.grafana.com/ingest: false\n\t\trule {\n\t\t\taction        = \"keep\"\n\t\t\tsource_labels
     = [\n\t\t\t\t\"__meta_kubernetes_pod_annotation_\" + argument.__sd_annotation.value
@@ -280,15 +279,12 @@ data:
     set the job label to be namespace / friendly pod name\n\t\trule {\n\t\t\taction
     \       = \"replace\"\n\t\t\tsource_labels = [\n\t\t\t\t\"workload\",\n\t\t\t\t\"__meta_kubernetes_namespace\",\n\t\t\t]\n\t\t\tregex
     \       = \".+\\\\/(.+);(.+)\"\n\t\t\treplacement  = \"$2/$1\"\n\t\t\ttarget_label
-    = \"job\"\n\t\t}\n\t}\n\n\tdiscovery.relabel \"worker_logs\" {\n\t\ttargets =
-    discovery.relabel.log_annotations.output\n\n\t\t// set the __path__, this is automatically
-    translated as a label of filename (which should be dropped or normalized)\n\t\t//
-    DO NOT delete this line as it is needed to tail the pod logs on the node\n\t\trule
-    {\n\t\t\taction        = \"replace\"\n\t\t\tseparator     = \"/\"\n\t\t\tsource_labels
-    = [\n\t\t\t\t\"__meta_kubernetes_pod_uid\",\n\t\t\t\t\"__meta_kubernetes_pod_container_name\",\n\t\t\t]\n\t\t\treplacement
-    \ = \"/var/log/pods/*$1/*.log\"\n\t\t\ttarget_label = \"__path__\"\n\t\t}\n\n\t\t//
-    set the __host__\n\t\trule {\n\t\t\taction        = \"replace\"\n\t\t\tsource_labels
-    = [\"__meta_kubernetes_pod_node_name\"]\n\t\t\ttarget_label  = \"__host__\"\n\t\t}\n\n\t\t//
+    = \"job\"\n\t\t}\n\n\t\t// make all labels on the pod available to the pipeline
+    as labels,\n\t\t// they are omitted before write via labelallow unless explicitly
+    set\n\t\trule {\n\t\t\taction = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_label_(.+)\"\n\t\t}\n\n\t\t//
+    make all annotations on the pod available to the pipeline as labels,\n\t\t// they
+    are omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
+    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_annotation_(.+)\"\n\t\t}\n\n\t\t//
     as a result of kubernetes service discovery for pods, all of the meta data information
     is exposed in labels\n\t\t// __meta_kubernetes_pod_*, including __meta_kubernetes_pod_container_id
     which can be used to determine what\n\t\t// the pods container runtime is, docker
@@ -299,19 +295,11 @@ data:
     automatically determined, then drop the label from the loki.process stage.\n\t\t//
     set the container runtime as a label\n\t\trule {\n\t\t\taction        = \"replace\"\n\t\t\tsource_labels
     = [\"__meta_kubernetes_pod_container_id\"]\n\t\t\tregex         = \"^(\\\\w+):\\\\/\\\\/.+$\"\n\t\t\treplacement
-    \  = \"$1\"\n\t\t\ttarget_label  = \"tmp_container_runtime\"\n\t\t}\n\n\t\t//
-    make all labels on the pod available to the pipeline as labels,\n\t\t// they are
-    omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
-    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_label_(.+)\"\n\t\t}\n\n\t\t//
-    make all annotations on the pod available to the pipeline as labels,\n\t\t// they
-    are omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
-    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_annotation_(.+)\"\n\t\t}\n\t}\n\n\t//
-    find eligible files on the worker\n\tlocal.file_match \"pods\" {\n\t\tpath_targets
-    = discovery.relabel.worker_logs.output\n\t}\n\n\t// tail the files\n\tloki.source.file
-    \"pods\" {\n\t\ttargets    = local.file_match.pods.targets\n\t\tforward_to = [loki.process.parse.receiver]\n\t}\n\n\t//
-    parse the log based on the container runtime\n\tloki.process \"parse\" {\n\t\tforward_to
-    = argument.forward_to.value\n\t\t/*******************************************************************************\n
-    \    *                         Container Runtime Parsing\n     ********************************************************************************/\n\t\t//
+    \  = \"$1\"\n\t\t\ttarget_label  = \"tmp_container_runtime\"\n\t\t}\n\t}\n\n\tloki.source.kubernetes
+    \"lsd_kubernetes_logs\" {\n\t\ttargets    = discovery.relabel.annotation_logs_filter.output\n\t\tforward_to
+    = [loki.process.parse.receiver]\n\t}\n\n\t// parse the log based on the container
+    runtime\n\tloki.process \"parse\" {\n\t\tforward_to = argument.forward_to.value\n\t\t/*******************************************************************************\n\t\t*
+    \                        Container Runtime Parsing\n\t\t********************************************************************************/\n\t\t//
     if the label tmp_container_runtime from above is containerd parse using cri\n\t\tstage.match
     {\n\t\t\tselector = \"{tmp_container_runtime=\\\"containerd\\\"}\"\n\t\t\t// the
     cri processing stage extracts the following k/v pairs: log, stream, time, flags\n\t\t\tstage.cri
@@ -347,7 +335,7 @@ data:
     \"receiver\" {\n\t\tvalue = loki.process.keep_labels.receiver\n\t}\n}\n"
 kind: ConfigMap
 metadata:
-  name: alloy-modules-kubernetes-logs-dfhkhc94gt
+  name: alloy-modules-kubernetes-logs-d7c756mt2f
   namespace: monitoring-system
 ---
 apiVersion: v1
@@ -2223,6 +2211,130 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
+    app.kubernetes.io/instance: alloy
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/version: v1.0.0
+    helm.sh/chart: alloy-0.1.1
+  name: alloy
+  namespace: monitoring-system
+spec:
+  minReadySeconds: 10
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: alloy
+      app.kubernetes.io/name: alloy
+  serviceName: alloy
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: alloy
+        logs.agent.grafana.com/scrape: "true"
+        logs.agent.grafana.com/scrub-level: debug
+        profiles.grafana.com/cpu.port_name: http-metrics
+        profiles.grafana.com/cpu.scrape: "false"
+        profiles.grafana.com/goroutine.port_name: http-metrics
+        profiles.grafana.com/goroutine.scrape: "false"
+        profiles.grafana.com/memory.port_name: http-metrics
+        profiles.grafana.com/memory.scrape: "false"
+        pyroscope.io/service_name: alloy
+      labels:
+        app.kubernetes.io/instance: alloy
+        app.kubernetes.io/name: alloy
+    spec:
+      containers:
+      - args:
+        - run
+        - /etc/alloy/config.alloy
+        - --storage.path=/tmp/alloy
+        - --server.http.listen-addr=0.0.0.0:12345
+        - --server.http.ui-path-prefix=/
+        - --disable-reporting
+        - --cluster.enabled=true
+        - --cluster.join-addresses=alloy-cluster
+        - --stability.level=experimental
+        env:
+        - name: ALLOY_DEPLOY_MODE
+          value: helm
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        envFrom:
+        - secretRef:
+            name: alloy-env
+            optional: true
+        image: docker.io/grafana/alloy:v1.0.0
+        imagePullPolicy: IfNotPresent
+        name: alloy
+        ports:
+        - containerPort: 12345
+          name: http-metrics
+        - containerPort: 4317
+          name: grpc-otlp
+          protocol: TCP
+        - containerPort: 4318
+          name: http-otlp
+          protocol: TCP
+        - containerPort: 9411
+          name: zipkin
+          protocol: TCP
+        - containerPort: 6831
+          name: jaeger-compact
+          protocol: UDP
+        readinessProbe:
+          httpGet:
+            path: /-/ready
+            port: 12345
+            scheme: HTTP
+          initialDelaySeconds: 10
+          timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /etc/alloy
+          name: config
+        - mountPath: /etc/alloy/modules/kubernetes/metrics
+          name: modules-kubernetes-metrics
+        - mountPath: /etc/alloy/modules/kubernetes/integrations
+          name: modules-kubernetes-integrations
+        - mountPath: /etc/alloy/modules/kubernetes/logs
+          name: modules-kubernetes-logs
+        - mountPath: /etc/alloy/modules/kubernetes/traces
+          name: modules-kubernetes-traces
+        - mountPath: /etc/alloy/modules/kubernetes/profiles
+          name: modules-kubernetes-profiles
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: alloy
+      volumes:
+      - configMap:
+          name: alloy-config-m6chdfm49m
+        name: config
+      - configMap:
+          name: alloy-modules-kubernetes-metrics-tf9cd8b6bg
+        name: modules-kubernetes-metrics
+      - configMap:
+          name: alloy-modules-kubernetes-integrations-9k86fb8hkg
+        name: modules-kubernetes-integrations
+      - configMap:
+          name: alloy-modules-kubernetes-logs-d7c756mt2f
+        name: modules-kubernetes-logs
+      - configMap:
+          name: alloy-modules-kubernetes-traces-8mgm8th9m5
+        name: modules-kubernetes-traces
+      - configMap:
+          name: alloy-modules-kubernetes-profiles-66c27bc84g
+        name: modules-kubernetes-profiles
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
     app.kubernetes.io/component: alertmanager
     app.kubernetes.io/instance: mimir-distributed
     app.kubernetes.io/managed-by: Helm
@@ -2949,135 +3061,6 @@ spec:
       app.kubernetes.io/component: store-gateway
       app.kubernetes.io/instance: mimir-distributed
       app.kubernetes.io/name: mimir
----
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  labels:
-    app.kubernetes.io/instance: alloy
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: alloy
-    app.kubernetes.io/version: v1.0.0
-    helm.sh/chart: alloy-0.1.1
-  name: alloy
-  namespace: monitoring-system
-spec:
-  minReadySeconds: 10
-  selector:
-    matchLabels:
-      app.kubernetes.io/instance: alloy
-      app.kubernetes.io/name: alloy
-  template:
-    metadata:
-      annotations:
-        kubectl.kubernetes.io/default-container: alloy
-        logs.agent.grafana.com/scrape: "true"
-        logs.agent.grafana.com/scrub-level: debug
-        profiles.grafana.com/cpu.port_name: http-metrics
-        profiles.grafana.com/cpu.scrape: "false"
-        profiles.grafana.com/goroutine.port_name: http-metrics
-        profiles.grafana.com/goroutine.scrape: "false"
-        profiles.grafana.com/memory.port_name: http-metrics
-        profiles.grafana.com/memory.scrape: "false"
-        pyroscope.io/service_name: alloy
-      labels:
-        app.kubernetes.io/instance: alloy
-        app.kubernetes.io/name: alloy
-    spec:
-      containers:
-      - args:
-        - run
-        - /etc/alloy/config.alloy
-        - --storage.path=/tmp/alloy
-        - --server.http.listen-addr=0.0.0.0:12345
-        - --server.http.ui-path-prefix=/
-        - --disable-reporting
-        - --cluster.enabled=true
-        - --cluster.join-addresses=alloy-cluster
-        - --stability.level=experimental
-        env:
-        - name: ALLOY_DEPLOY_MODE
-          value: helm
-        - name: HOSTNAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        envFrom:
-        - secretRef:
-            name: alloy-env
-            optional: true
-        image: docker.io/grafana/alloy:v1.0.0
-        imagePullPolicy: IfNotPresent
-        name: alloy
-        ports:
-        - containerPort: 12345
-          name: http-metrics
-        - containerPort: 4317
-          name: grpc-otlp
-          protocol: TCP
-        - containerPort: 4318
-          name: http-otlp
-          protocol: TCP
-        - containerPort: 9411
-          name: zipkin
-          protocol: TCP
-        - containerPort: 6831
-          name: jaeger-compact
-          protocol: UDP
-        readinessProbe:
-          httpGet:
-            path: /-/ready
-            port: 12345
-            scheme: HTTP
-          initialDelaySeconds: 10
-          timeoutSeconds: 1
-        volumeMounts:
-        - mountPath: /etc/alloy
-          name: config
-        - mountPath: /var/log
-          name: varlog
-          readOnly: true
-        - mountPath: /etc/alloy/modules/kubernetes/metrics
-          name: modules-kubernetes-metrics
-        - mountPath: /etc/alloy/modules/kubernetes/integrations
-          name: modules-kubernetes-integrations
-        - mountPath: /etc/alloy/modules/kubernetes/logs
-          name: modules-kubernetes-logs
-        - mountPath: /etc/alloy/modules/kubernetes/traces
-          name: modules-kubernetes-traces
-        - mountPath: /etc/alloy/modules/kubernetes/profiles
-          name: modules-kubernetes-profiles
-      dnsPolicy: ClusterFirst
-      nodeSelector:
-        kubernetes.io/os: linux
-      serviceAccountName: alloy
-      volumes:
-      - configMap:
-          name: alloy-config-m6chdfm49m
-        name: config
-      - hostPath:
-          path: /var/log
-        name: varlog
-      - configMap:
-          name: alloy-modules-kubernetes-metrics-tf9cd8b6bg
-        name: modules-kubernetes-metrics
-      - configMap:
-          name: alloy-modules-kubernetes-integrations-9k86fb8hkg
-        name: modules-kubernetes-integrations
-      - configMap:
-          name: alloy-modules-kubernetes-logs-dfhkhc94gt
-        name: modules-kubernetes-logs
-      - configMap:
-          name: alloy-modules-kubernetes-traces-8mgm8th9m5
-        name: modules-kubernetes-traces
-      - configMap:
-          name: alloy-modules-kubernetes-profiles-66c27bc84g
-        name: modules-kubernetes-profiles
-  updateStrategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 2
-    type: RollingUpdate
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/kubernetes/microservices-mode/profiles/k8s-all-in-one.yaml
+++ b/kubernetes/microservices-mode/profiles/k8s-all-in-one.yaml
@@ -296,15 +296,14 @@ data:
     to look for targets in (default: [\\\"kube-system\\\"] is all namespaces)\"\n\t\toptional
     = true\n\t}\n\n\targument \"annotation_prefix\" {\n\t\tcomment  = \"The annotation_prefix
     to use (default: logs.grafana.com)\"\n\t\tdefault  = \"logs.grafana.com\"\n\t\toptional
-    = true\n\t}\n\n\t/*\n    Hidden Arguments\n    These arguments are used to set
-    reusable variables to avoid repeating logic\n  */\n\targument \"__sd_annotation\"
-    {\n\t\toptional = true\n\t\tcomment  = \"The logic is used to transform the annotation
-    argument into a valid label name by removing unsupported characters.\"\n\t\tdefault
-    \ = replace(replace(replace(coalesce(argument.annotation_prefix.value, \"logs.grafana.com\"),
-    \".\", \"_\"), \"/\", \"_\"), \"-\", \"_\")\n\t}\n\n\t// find all pods\n\tdiscovery.kubernetes
-    \"log_annotations\" {\n\t\trole = \"pod\"\n\n\t\tnamespaces {\n\t\t\tnames = coalesce(argument.namespaces.value,
-    [])\n\t\t}\n\t}\n\n\t// apply relabelings\n\tdiscovery.relabel \"log_annotations\"
-    {\n\t\ttargets = discovery.kubernetes.log_annotations.targets\n\n\t\t// allow
+    = true\n\t}\n\n\targument \"__sd_annotation\" {\n\t\toptional = true\n\t\tcomment
+    \ = \"The logic is used to transform the annotation argument into a valid label
+    name by removing unsupported characters.\"\n\t\tdefault  = replace(replace(replace(coalesce(argument.annotation_prefix.value,
+    \"logs.grafana.com\"), \".\", \"_\"), \"/\", \"_\"), \"-\", \"_\")\n\t}\n\n\t//
+    find all pods\n\tdiscovery.kubernetes \"annotation_logs\" {\n\t\trole = \"pod\"\n\n\t\tnamespaces
+    {\n\t\t\tnames = coalesce(argument.namespaces.value, [])\n\t\t}\n\t}\n\n\t// filter
+    logs by kubernetes annotations\n\tdiscovery.relabel \"annotation_logs_filter\"
+    {\n\t\ttargets = discovery.kubernetes.annotation_logs.targets\n\n\t\t// allow
     pods to declare their logs to be ingested or not, the default is true\n\t\t//
     \  i.e. logs.grafana.com/ingest: false\n\t\trule {\n\t\t\taction        = \"keep\"\n\t\t\tsource_labels
     = [\n\t\t\t\t\"__meta_kubernetes_pod_annotation_\" + argument.__sd_annotation.value
@@ -342,15 +341,12 @@ data:
     set the job label to be namespace / friendly pod name\n\t\trule {\n\t\t\taction
     \       = \"replace\"\n\t\t\tsource_labels = [\n\t\t\t\t\"workload\",\n\t\t\t\t\"__meta_kubernetes_namespace\",\n\t\t\t]\n\t\t\tregex
     \       = \".+\\\\/(.+);(.+)\"\n\t\t\treplacement  = \"$2/$1\"\n\t\t\ttarget_label
-    = \"job\"\n\t\t}\n\t}\n\n\tdiscovery.relabel \"worker_logs\" {\n\t\ttargets =
-    discovery.relabel.log_annotations.output\n\n\t\t// set the __path__, this is automatically
-    translated as a label of filename (which should be dropped or normalized)\n\t\t//
-    DO NOT delete this line as it is needed to tail the pod logs on the node\n\t\trule
-    {\n\t\t\taction        = \"replace\"\n\t\t\tseparator     = \"/\"\n\t\t\tsource_labels
-    = [\n\t\t\t\t\"__meta_kubernetes_pod_uid\",\n\t\t\t\t\"__meta_kubernetes_pod_container_name\",\n\t\t\t]\n\t\t\treplacement
-    \ = \"/var/log/pods/*$1/*.log\"\n\t\t\ttarget_label = \"__path__\"\n\t\t}\n\n\t\t//
-    set the __host__\n\t\trule {\n\t\t\taction        = \"replace\"\n\t\t\tsource_labels
-    = [\"__meta_kubernetes_pod_node_name\"]\n\t\t\ttarget_label  = \"__host__\"\n\t\t}\n\n\t\t//
+    = \"job\"\n\t\t}\n\n\t\t// make all labels on the pod available to the pipeline
+    as labels,\n\t\t// they are omitted before write via labelallow unless explicitly
+    set\n\t\trule {\n\t\t\taction = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_label_(.+)\"\n\t\t}\n\n\t\t//
+    make all annotations on the pod available to the pipeline as labels,\n\t\t// they
+    are omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
+    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_annotation_(.+)\"\n\t\t}\n\n\t\t//
     as a result of kubernetes service discovery for pods, all of the meta data information
     is exposed in labels\n\t\t// __meta_kubernetes_pod_*, including __meta_kubernetes_pod_container_id
     which can be used to determine what\n\t\t// the pods container runtime is, docker
@@ -361,19 +357,11 @@ data:
     automatically determined, then drop the label from the loki.process stage.\n\t\t//
     set the container runtime as a label\n\t\trule {\n\t\t\taction        = \"replace\"\n\t\t\tsource_labels
     = [\"__meta_kubernetes_pod_container_id\"]\n\t\t\tregex         = \"^(\\\\w+):\\\\/\\\\/.+$\"\n\t\t\treplacement
-    \  = \"$1\"\n\t\t\ttarget_label  = \"tmp_container_runtime\"\n\t\t}\n\n\t\t//
-    make all labels on the pod available to the pipeline as labels,\n\t\t// they are
-    omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
-    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_label_(.+)\"\n\t\t}\n\n\t\t//
-    make all annotations on the pod available to the pipeline as labels,\n\t\t// they
-    are omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
-    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_annotation_(.+)\"\n\t\t}\n\t}\n\n\t//
-    find eligible files on the worker\n\tlocal.file_match \"pods\" {\n\t\tpath_targets
-    = discovery.relabel.worker_logs.output\n\t}\n\n\t// tail the files\n\tloki.source.file
-    \"pods\" {\n\t\ttargets    = local.file_match.pods.targets\n\t\tforward_to = [loki.process.parse.receiver]\n\t}\n\n\t//
-    parse the log based on the container runtime\n\tloki.process \"parse\" {\n\t\tforward_to
-    = argument.forward_to.value\n\t\t/*******************************************************************************\n
-    \    *                         Container Runtime Parsing\n     ********************************************************************************/\n\t\t//
+    \  = \"$1\"\n\t\t\ttarget_label  = \"tmp_container_runtime\"\n\t\t}\n\t}\n\n\tloki.source.kubernetes
+    \"lsd_kubernetes_logs\" {\n\t\ttargets    = discovery.relabel.annotation_logs_filter.output\n\t\tforward_to
+    = [loki.process.parse.receiver]\n\t}\n\n\t// parse the log based on the container
+    runtime\n\tloki.process \"parse\" {\n\t\tforward_to = argument.forward_to.value\n\t\t/*******************************************************************************\n\t\t*
+    \                        Container Runtime Parsing\n\t\t********************************************************************************/\n\t\t//
     if the label tmp_container_runtime from above is containerd parse using cri\n\t\tstage.match
     {\n\t\t\tselector = \"{tmp_container_runtime=\\\"containerd\\\"}\"\n\t\t\t// the
     cri processing stage extracts the following k/v pairs: log, stream, time, flags\n\t\t\tstage.cri
@@ -409,7 +397,7 @@ data:
     \"receiver\" {\n\t\tvalue = loki.process.keep_labels.receiver\n\t}\n}\n"
 kind: ConfigMap
 metadata:
-  name: alloy-modules-kubernetes-logs-dfhkhc94gt
+  name: alloy-modules-kubernetes-logs-d7c756mt2f
   namespace: monitoring-system
 ---
 apiVersion: v1
@@ -1946,6 +1934,130 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
+    app.kubernetes.io/instance: alloy
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/version: v1.0.0
+    helm.sh/chart: alloy-0.1.1
+  name: alloy
+  namespace: monitoring-system
+spec:
+  minReadySeconds: 10
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: alloy
+      app.kubernetes.io/name: alloy
+  serviceName: alloy
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: alloy
+        logs.agent.grafana.com/scrape: "true"
+        logs.agent.grafana.com/scrub-level: debug
+        profiles.grafana.com/cpu.port_name: http-metrics
+        profiles.grafana.com/cpu.scrape: "false"
+        profiles.grafana.com/goroutine.port_name: http-metrics
+        profiles.grafana.com/goroutine.scrape: "false"
+        profiles.grafana.com/memory.port_name: http-metrics
+        profiles.grafana.com/memory.scrape: "false"
+        pyroscope.io/service_name: alloy
+      labels:
+        app.kubernetes.io/instance: alloy
+        app.kubernetes.io/name: alloy
+    spec:
+      containers:
+      - args:
+        - run
+        - /etc/alloy/config.alloy
+        - --storage.path=/tmp/alloy
+        - --server.http.listen-addr=0.0.0.0:12345
+        - --server.http.ui-path-prefix=/
+        - --disable-reporting
+        - --cluster.enabled=true
+        - --cluster.join-addresses=alloy-cluster
+        - --stability.level=experimental
+        env:
+        - name: ALLOY_DEPLOY_MODE
+          value: helm
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        envFrom:
+        - secretRef:
+            name: alloy-env
+            optional: true
+        image: docker.io/grafana/alloy:v1.0.0
+        imagePullPolicy: IfNotPresent
+        name: alloy
+        ports:
+        - containerPort: 12345
+          name: http-metrics
+        - containerPort: 4317
+          name: grpc-otlp
+          protocol: TCP
+        - containerPort: 4318
+          name: http-otlp
+          protocol: TCP
+        - containerPort: 9411
+          name: zipkin
+          protocol: TCP
+        - containerPort: 6831
+          name: jaeger-compact
+          protocol: UDP
+        readinessProbe:
+          httpGet:
+            path: /-/ready
+            port: 12345
+            scheme: HTTP
+          initialDelaySeconds: 10
+          timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /etc/alloy
+          name: config
+        - mountPath: /etc/alloy/modules/kubernetes/metrics
+          name: modules-kubernetes-metrics
+        - mountPath: /etc/alloy/modules/kubernetes/integrations
+          name: modules-kubernetes-integrations
+        - mountPath: /etc/alloy/modules/kubernetes/logs
+          name: modules-kubernetes-logs
+        - mountPath: /etc/alloy/modules/kubernetes/traces
+          name: modules-kubernetes-traces
+        - mountPath: /etc/alloy/modules/kubernetes/profiles
+          name: modules-kubernetes-profiles
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: alloy
+      volumes:
+      - configMap:
+          name: alloy-config-5k62427t46
+        name: config
+      - configMap:
+          name: alloy-modules-kubernetes-metrics-tf9cd8b6bg
+        name: modules-kubernetes-metrics
+      - configMap:
+          name: alloy-modules-kubernetes-integrations-9k86fb8hkg
+        name: modules-kubernetes-integrations
+      - configMap:
+          name: alloy-modules-kubernetes-logs-d7c756mt2f
+        name: modules-kubernetes-logs
+      - configMap:
+          name: alloy-modules-kubernetes-traces-8mgm8th9m5
+        name: modules-kubernetes-traces
+      - configMap:
+          name: alloy-modules-kubernetes-profiles-66c27bc84g
+        name: modules-kubernetes-profiles
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
     app.kubernetes.io/component: compactor
     app.kubernetes.io/instance: pyroscope
     app.kubernetes.io/managed-by: Helm
@@ -2225,135 +2337,6 @@ spec:
         name: overrides-config
       - emptyDir: {}
         name: data
----
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  labels:
-    app.kubernetes.io/instance: alloy
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: alloy
-    app.kubernetes.io/version: v1.0.0
-    helm.sh/chart: alloy-0.1.1
-  name: alloy
-  namespace: monitoring-system
-spec:
-  minReadySeconds: 10
-  selector:
-    matchLabels:
-      app.kubernetes.io/instance: alloy
-      app.kubernetes.io/name: alloy
-  template:
-    metadata:
-      annotations:
-        kubectl.kubernetes.io/default-container: alloy
-        logs.agent.grafana.com/scrape: "true"
-        logs.agent.grafana.com/scrub-level: debug
-        profiles.grafana.com/cpu.port_name: http-metrics
-        profiles.grafana.com/cpu.scrape: "false"
-        profiles.grafana.com/goroutine.port_name: http-metrics
-        profiles.grafana.com/goroutine.scrape: "false"
-        profiles.grafana.com/memory.port_name: http-metrics
-        profiles.grafana.com/memory.scrape: "false"
-        pyroscope.io/service_name: alloy
-      labels:
-        app.kubernetes.io/instance: alloy
-        app.kubernetes.io/name: alloy
-    spec:
-      containers:
-      - args:
-        - run
-        - /etc/alloy/config.alloy
-        - --storage.path=/tmp/alloy
-        - --server.http.listen-addr=0.0.0.0:12345
-        - --server.http.ui-path-prefix=/
-        - --disable-reporting
-        - --cluster.enabled=true
-        - --cluster.join-addresses=alloy-cluster
-        - --stability.level=experimental
-        env:
-        - name: ALLOY_DEPLOY_MODE
-          value: helm
-        - name: HOSTNAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        envFrom:
-        - secretRef:
-            name: alloy-env
-            optional: true
-        image: docker.io/grafana/alloy:v1.0.0
-        imagePullPolicy: IfNotPresent
-        name: alloy
-        ports:
-        - containerPort: 12345
-          name: http-metrics
-        - containerPort: 4317
-          name: grpc-otlp
-          protocol: TCP
-        - containerPort: 4318
-          name: http-otlp
-          protocol: TCP
-        - containerPort: 9411
-          name: zipkin
-          protocol: TCP
-        - containerPort: 6831
-          name: jaeger-compact
-          protocol: UDP
-        readinessProbe:
-          httpGet:
-            path: /-/ready
-            port: 12345
-            scheme: HTTP
-          initialDelaySeconds: 10
-          timeoutSeconds: 1
-        volumeMounts:
-        - mountPath: /etc/alloy
-          name: config
-        - mountPath: /var/log
-          name: varlog
-          readOnly: true
-        - mountPath: /etc/alloy/modules/kubernetes/metrics
-          name: modules-kubernetes-metrics
-        - mountPath: /etc/alloy/modules/kubernetes/integrations
-          name: modules-kubernetes-integrations
-        - mountPath: /etc/alloy/modules/kubernetes/logs
-          name: modules-kubernetes-logs
-        - mountPath: /etc/alloy/modules/kubernetes/traces
-          name: modules-kubernetes-traces
-        - mountPath: /etc/alloy/modules/kubernetes/profiles
-          name: modules-kubernetes-profiles
-      dnsPolicy: ClusterFirst
-      nodeSelector:
-        kubernetes.io/os: linux
-      serviceAccountName: alloy
-      volumes:
-      - configMap:
-          name: alloy-config-5k62427t46
-        name: config
-      - hostPath:
-          path: /var/log
-        name: varlog
-      - configMap:
-          name: alloy-modules-kubernetes-metrics-tf9cd8b6bg
-        name: modules-kubernetes-metrics
-      - configMap:
-          name: alloy-modules-kubernetes-integrations-9k86fb8hkg
-        name: modules-kubernetes-integrations
-      - configMap:
-          name: alloy-modules-kubernetes-logs-dfhkhc94gt
-        name: modules-kubernetes-logs
-      - configMap:
-          name: alloy-modules-kubernetes-traces-8mgm8th9m5
-        name: modules-kubernetes-traces
-      - configMap:
-          name: alloy-modules-kubernetes-profiles-66c27bc84g
-        name: modules-kubernetes-profiles
-  updateStrategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 2
-    type: RollingUpdate
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/kubernetes/microservices-mode/traces/k8s-all-in-one.yaml
+++ b/kubernetes/microservices-mode/traces/k8s-all-in-one.yaml
@@ -308,15 +308,14 @@ data:
     to look for targets in (default: [\\\"kube-system\\\"] is all namespaces)\"\n\t\toptional
     = true\n\t}\n\n\targument \"annotation_prefix\" {\n\t\tcomment  = \"The annotation_prefix
     to use (default: logs.grafana.com)\"\n\t\tdefault  = \"logs.grafana.com\"\n\t\toptional
-    = true\n\t}\n\n\t/*\n    Hidden Arguments\n    These arguments are used to set
-    reusable variables to avoid repeating logic\n  */\n\targument \"__sd_annotation\"
-    {\n\t\toptional = true\n\t\tcomment  = \"The logic is used to transform the annotation
-    argument into a valid label name by removing unsupported characters.\"\n\t\tdefault
-    \ = replace(replace(replace(coalesce(argument.annotation_prefix.value, \"logs.grafana.com\"),
-    \".\", \"_\"), \"/\", \"_\"), \"-\", \"_\")\n\t}\n\n\t// find all pods\n\tdiscovery.kubernetes
-    \"log_annotations\" {\n\t\trole = \"pod\"\n\n\t\tnamespaces {\n\t\t\tnames = coalesce(argument.namespaces.value,
-    [])\n\t\t}\n\t}\n\n\t// apply relabelings\n\tdiscovery.relabel \"log_annotations\"
-    {\n\t\ttargets = discovery.kubernetes.log_annotations.targets\n\n\t\t// allow
+    = true\n\t}\n\n\targument \"__sd_annotation\" {\n\t\toptional = true\n\t\tcomment
+    \ = \"The logic is used to transform the annotation argument into a valid label
+    name by removing unsupported characters.\"\n\t\tdefault  = replace(replace(replace(coalesce(argument.annotation_prefix.value,
+    \"logs.grafana.com\"), \".\", \"_\"), \"/\", \"_\"), \"-\", \"_\")\n\t}\n\n\t//
+    find all pods\n\tdiscovery.kubernetes \"annotation_logs\" {\n\t\trole = \"pod\"\n\n\t\tnamespaces
+    {\n\t\t\tnames = coalesce(argument.namespaces.value, [])\n\t\t}\n\t}\n\n\t// filter
+    logs by kubernetes annotations\n\tdiscovery.relabel \"annotation_logs_filter\"
+    {\n\t\ttargets = discovery.kubernetes.annotation_logs.targets\n\n\t\t// allow
     pods to declare their logs to be ingested or not, the default is true\n\t\t//
     \  i.e. logs.grafana.com/ingest: false\n\t\trule {\n\t\t\taction        = \"keep\"\n\t\t\tsource_labels
     = [\n\t\t\t\t\"__meta_kubernetes_pod_annotation_\" + argument.__sd_annotation.value
@@ -354,15 +353,12 @@ data:
     set the job label to be namespace / friendly pod name\n\t\trule {\n\t\t\taction
     \       = \"replace\"\n\t\t\tsource_labels = [\n\t\t\t\t\"workload\",\n\t\t\t\t\"__meta_kubernetes_namespace\",\n\t\t\t]\n\t\t\tregex
     \       = \".+\\\\/(.+);(.+)\"\n\t\t\treplacement  = \"$2/$1\"\n\t\t\ttarget_label
-    = \"job\"\n\t\t}\n\t}\n\n\tdiscovery.relabel \"worker_logs\" {\n\t\ttargets =
-    discovery.relabel.log_annotations.output\n\n\t\t// set the __path__, this is automatically
-    translated as a label of filename (which should be dropped or normalized)\n\t\t//
-    DO NOT delete this line as it is needed to tail the pod logs on the node\n\t\trule
-    {\n\t\t\taction        = \"replace\"\n\t\t\tseparator     = \"/\"\n\t\t\tsource_labels
-    = [\n\t\t\t\t\"__meta_kubernetes_pod_uid\",\n\t\t\t\t\"__meta_kubernetes_pod_container_name\",\n\t\t\t]\n\t\t\treplacement
-    \ = \"/var/log/pods/*$1/*.log\"\n\t\t\ttarget_label = \"__path__\"\n\t\t}\n\n\t\t//
-    set the __host__\n\t\trule {\n\t\t\taction        = \"replace\"\n\t\t\tsource_labels
-    = [\"__meta_kubernetes_pod_node_name\"]\n\t\t\ttarget_label  = \"__host__\"\n\t\t}\n\n\t\t//
+    = \"job\"\n\t\t}\n\n\t\t// make all labels on the pod available to the pipeline
+    as labels,\n\t\t// they are omitted before write via labelallow unless explicitly
+    set\n\t\trule {\n\t\t\taction = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_label_(.+)\"\n\t\t}\n\n\t\t//
+    make all annotations on the pod available to the pipeline as labels,\n\t\t// they
+    are omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
+    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_annotation_(.+)\"\n\t\t}\n\n\t\t//
     as a result of kubernetes service discovery for pods, all of the meta data information
     is exposed in labels\n\t\t// __meta_kubernetes_pod_*, including __meta_kubernetes_pod_container_id
     which can be used to determine what\n\t\t// the pods container runtime is, docker
@@ -373,19 +369,11 @@ data:
     automatically determined, then drop the label from the loki.process stage.\n\t\t//
     set the container runtime as a label\n\t\trule {\n\t\t\taction        = \"replace\"\n\t\t\tsource_labels
     = [\"__meta_kubernetes_pod_container_id\"]\n\t\t\tregex         = \"^(\\\\w+):\\\\/\\\\/.+$\"\n\t\t\treplacement
-    \  = \"$1\"\n\t\t\ttarget_label  = \"tmp_container_runtime\"\n\t\t}\n\n\t\t//
-    make all labels on the pod available to the pipeline as labels,\n\t\t// they are
-    omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
-    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_label_(.+)\"\n\t\t}\n\n\t\t//
-    make all annotations on the pod available to the pipeline as labels,\n\t\t// they
-    are omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
-    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_annotation_(.+)\"\n\t\t}\n\t}\n\n\t//
-    find eligible files on the worker\n\tlocal.file_match \"pods\" {\n\t\tpath_targets
-    = discovery.relabel.worker_logs.output\n\t}\n\n\t// tail the files\n\tloki.source.file
-    \"pods\" {\n\t\ttargets    = local.file_match.pods.targets\n\t\tforward_to = [loki.process.parse.receiver]\n\t}\n\n\t//
-    parse the log based on the container runtime\n\tloki.process \"parse\" {\n\t\tforward_to
-    = argument.forward_to.value\n\t\t/*******************************************************************************\n
-    \    *                         Container Runtime Parsing\n     ********************************************************************************/\n\t\t//
+    \  = \"$1\"\n\t\t\ttarget_label  = \"tmp_container_runtime\"\n\t\t}\n\t}\n\n\tloki.source.kubernetes
+    \"lsd_kubernetes_logs\" {\n\t\ttargets    = discovery.relabel.annotation_logs_filter.output\n\t\tforward_to
+    = [loki.process.parse.receiver]\n\t}\n\n\t// parse the log based on the container
+    runtime\n\tloki.process \"parse\" {\n\t\tforward_to = argument.forward_to.value\n\t\t/*******************************************************************************\n\t\t*
+    \                        Container Runtime Parsing\n\t\t********************************************************************************/\n\t\t//
     if the label tmp_container_runtime from above is containerd parse using cri\n\t\tstage.match
     {\n\t\t\tselector = \"{tmp_container_runtime=\\\"containerd\\\"}\"\n\t\t\t// the
     cri processing stage extracts the following k/v pairs: log, stream, time, flags\n\t\t\tstage.cri
@@ -421,7 +409,7 @@ data:
     \"receiver\" {\n\t\tvalue = loki.process.keep_labels.receiver\n\t}\n}\n"
 kind: ConfigMap
 metadata:
-  name: alloy-modules-kubernetes-logs-dfhkhc94gt
+  name: alloy-modules-kubernetes-logs-d7c756mt2f
   namespace: monitoring-system
 ---
 apiVersion: v1
@@ -2291,6 +2279,130 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
+    app.kubernetes.io/instance: alloy
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/version: v1.0.0
+    helm.sh/chart: alloy-0.1.1
+  name: alloy
+  namespace: monitoring-system
+spec:
+  minReadySeconds: 10
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: alloy
+      app.kubernetes.io/name: alloy
+  serviceName: alloy
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: alloy
+        logs.agent.grafana.com/scrape: "true"
+        logs.agent.grafana.com/scrub-level: debug
+        profiles.grafana.com/cpu.port_name: http-metrics
+        profiles.grafana.com/cpu.scrape: "false"
+        profiles.grafana.com/goroutine.port_name: http-metrics
+        profiles.grafana.com/goroutine.scrape: "false"
+        profiles.grafana.com/memory.port_name: http-metrics
+        profiles.grafana.com/memory.scrape: "false"
+        pyroscope.io/service_name: alloy
+      labels:
+        app.kubernetes.io/instance: alloy
+        app.kubernetes.io/name: alloy
+    spec:
+      containers:
+      - args:
+        - run
+        - /etc/alloy/config.alloy
+        - --storage.path=/tmp/alloy
+        - --server.http.listen-addr=0.0.0.0:12345
+        - --server.http.ui-path-prefix=/
+        - --disable-reporting
+        - --cluster.enabled=true
+        - --cluster.join-addresses=alloy-cluster
+        - --stability.level=experimental
+        env:
+        - name: ALLOY_DEPLOY_MODE
+          value: helm
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        envFrom:
+        - secretRef:
+            name: alloy-env
+            optional: true
+        image: docker.io/grafana/alloy:v1.0.0
+        imagePullPolicy: IfNotPresent
+        name: alloy
+        ports:
+        - containerPort: 12345
+          name: http-metrics
+        - containerPort: 4317
+          name: grpc-otlp
+          protocol: TCP
+        - containerPort: 4318
+          name: http-otlp
+          protocol: TCP
+        - containerPort: 9411
+          name: zipkin
+          protocol: TCP
+        - containerPort: 6831
+          name: jaeger-compact
+          protocol: UDP
+        readinessProbe:
+          httpGet:
+            path: /-/ready
+            port: 12345
+            scheme: HTTP
+          initialDelaySeconds: 10
+          timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /etc/alloy
+          name: config
+        - mountPath: /etc/alloy/modules/kubernetes/metrics
+          name: modules-kubernetes-metrics
+        - mountPath: /etc/alloy/modules/kubernetes/integrations
+          name: modules-kubernetes-integrations
+        - mountPath: /etc/alloy/modules/kubernetes/logs
+          name: modules-kubernetes-logs
+        - mountPath: /etc/alloy/modules/kubernetes/traces
+          name: modules-kubernetes-traces
+        - mountPath: /etc/alloy/modules/kubernetes/profiles
+          name: modules-kubernetes-profiles
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: alloy
+      volumes:
+      - configMap:
+          name: alloy-config-gt2k68744f
+        name: config
+      - configMap:
+          name: alloy-modules-kubernetes-metrics-tf9cd8b6bg
+        name: modules-kubernetes-metrics
+      - configMap:
+          name: alloy-modules-kubernetes-integrations-9k86fb8hkg
+        name: modules-kubernetes-integrations
+      - configMap:
+          name: alloy-modules-kubernetes-logs-d7c756mt2f
+        name: modules-kubernetes-logs
+      - configMap:
+          name: alloy-modules-kubernetes-traces-8mgm8th9m5
+        name: modules-kubernetes-traces
+      - configMap:
+          name: alloy-modules-kubernetes-profiles-66c27bc84g
+        name: modules-kubernetes-profiles
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
     app.kubernetes.io/component: ingester
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/managed-by: Helm
@@ -2444,135 +2556,6 @@ spec:
       app.kubernetes.io/component: ingester
       app.kubernetes.io/instance: tempo-distributed
       app.kubernetes.io/name: tempo
----
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  labels:
-    app.kubernetes.io/instance: alloy
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: alloy
-    app.kubernetes.io/version: v1.0.0
-    helm.sh/chart: alloy-0.1.1
-  name: alloy
-  namespace: monitoring-system
-spec:
-  minReadySeconds: 10
-  selector:
-    matchLabels:
-      app.kubernetes.io/instance: alloy
-      app.kubernetes.io/name: alloy
-  template:
-    metadata:
-      annotations:
-        kubectl.kubernetes.io/default-container: alloy
-        logs.agent.grafana.com/scrape: "true"
-        logs.agent.grafana.com/scrub-level: debug
-        profiles.grafana.com/cpu.port_name: http-metrics
-        profiles.grafana.com/cpu.scrape: "false"
-        profiles.grafana.com/goroutine.port_name: http-metrics
-        profiles.grafana.com/goroutine.scrape: "false"
-        profiles.grafana.com/memory.port_name: http-metrics
-        profiles.grafana.com/memory.scrape: "false"
-        pyroscope.io/service_name: alloy
-      labels:
-        app.kubernetes.io/instance: alloy
-        app.kubernetes.io/name: alloy
-    spec:
-      containers:
-      - args:
-        - run
-        - /etc/alloy/config.alloy
-        - --storage.path=/tmp/alloy
-        - --server.http.listen-addr=0.0.0.0:12345
-        - --server.http.ui-path-prefix=/
-        - --disable-reporting
-        - --cluster.enabled=true
-        - --cluster.join-addresses=alloy-cluster
-        - --stability.level=experimental
-        env:
-        - name: ALLOY_DEPLOY_MODE
-          value: helm
-        - name: HOSTNAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        envFrom:
-        - secretRef:
-            name: alloy-env
-            optional: true
-        image: docker.io/grafana/alloy:v1.0.0
-        imagePullPolicy: IfNotPresent
-        name: alloy
-        ports:
-        - containerPort: 12345
-          name: http-metrics
-        - containerPort: 4317
-          name: grpc-otlp
-          protocol: TCP
-        - containerPort: 4318
-          name: http-otlp
-          protocol: TCP
-        - containerPort: 9411
-          name: zipkin
-          protocol: TCP
-        - containerPort: 6831
-          name: jaeger-compact
-          protocol: UDP
-        readinessProbe:
-          httpGet:
-            path: /-/ready
-            port: 12345
-            scheme: HTTP
-          initialDelaySeconds: 10
-          timeoutSeconds: 1
-        volumeMounts:
-        - mountPath: /etc/alloy
-          name: config
-        - mountPath: /var/log
-          name: varlog
-          readOnly: true
-        - mountPath: /etc/alloy/modules/kubernetes/metrics
-          name: modules-kubernetes-metrics
-        - mountPath: /etc/alloy/modules/kubernetes/integrations
-          name: modules-kubernetes-integrations
-        - mountPath: /etc/alloy/modules/kubernetes/logs
-          name: modules-kubernetes-logs
-        - mountPath: /etc/alloy/modules/kubernetes/traces
-          name: modules-kubernetes-traces
-        - mountPath: /etc/alloy/modules/kubernetes/profiles
-          name: modules-kubernetes-profiles
-      dnsPolicy: ClusterFirst
-      nodeSelector:
-        kubernetes.io/os: linux
-      serviceAccountName: alloy
-      volumes:
-      - configMap:
-          name: alloy-config-gt2k68744f
-        name: config
-      - hostPath:
-          path: /var/log
-        name: varlog
-      - configMap:
-          name: alloy-modules-kubernetes-metrics-tf9cd8b6bg
-        name: modules-kubernetes-metrics
-      - configMap:
-          name: alloy-modules-kubernetes-integrations-9k86fb8hkg
-        name: modules-kubernetes-integrations
-      - configMap:
-          name: alloy-modules-kubernetes-logs-dfhkhc94gt
-        name: modules-kubernetes-logs
-      - configMap:
-          name: alloy-modules-kubernetes-traces-8mgm8th9m5
-        name: modules-kubernetes-traces
-      - configMap:
-          name: alloy-modules-kubernetes-profiles-66c27bc84g
-        name: modules-kubernetes-profiles
-  updateStrategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 2
-    type: RollingUpdate
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/kubernetes/monolithic-mode/all-in-one/k8s-all-in-one.yaml
+++ b/kubernetes/monolithic-mode/all-in-one/k8s-all-in-one.yaml
@@ -573,8 +573,8 @@ data:
 
     storage_config:
       tsdb_shipper:
-        active_index_directory: /loki/index
-        cache_location: /loki/cache
+        active_index_directory: /var/loki/index
+        cache_location: /var/loki/cache
         index_gateway_client:
           server_address: "dns+loki.logging-system.svc.cluster.local:9095"
 
@@ -590,7 +590,7 @@ metadata:
     app.kubernetes.io/managed-by: Kustomize
     app.kubernetes.io/name: loki
     app.kubernetes.io/version: 3.0.0
-  name: loki-config-5h5fcktftg
+  name: loki-config-5468cb29k9
   namespace: logging-system
 ---
 apiVersion: v1
@@ -714,15 +714,14 @@ data:
     to look for targets in (default: [\\\"kube-system\\\"] is all namespaces)\"\n\t\toptional
     = true\n\t}\n\n\targument \"annotation_prefix\" {\n\t\tcomment  = \"The annotation_prefix
     to use (default: logs.grafana.com)\"\n\t\tdefault  = \"logs.grafana.com\"\n\t\toptional
-    = true\n\t}\n\n\t/*\n    Hidden Arguments\n    These arguments are used to set
-    reusable variables to avoid repeating logic\n  */\n\targument \"__sd_annotation\"
-    {\n\t\toptional = true\n\t\tcomment  = \"The logic is used to transform the annotation
-    argument into a valid label name by removing unsupported characters.\"\n\t\tdefault
-    \ = replace(replace(replace(coalesce(argument.annotation_prefix.value, \"logs.grafana.com\"),
-    \".\", \"_\"), \"/\", \"_\"), \"-\", \"_\")\n\t}\n\n\t// find all pods\n\tdiscovery.kubernetes
-    \"log_annotations\" {\n\t\trole = \"pod\"\n\n\t\tnamespaces {\n\t\t\tnames = coalesce(argument.namespaces.value,
-    [])\n\t\t}\n\t}\n\n\t// apply relabelings\n\tdiscovery.relabel \"log_annotations\"
-    {\n\t\ttargets = discovery.kubernetes.log_annotations.targets\n\n\t\t// allow
+    = true\n\t}\n\n\targument \"__sd_annotation\" {\n\t\toptional = true\n\t\tcomment
+    \ = \"The logic is used to transform the annotation argument into a valid label
+    name by removing unsupported characters.\"\n\t\tdefault  = replace(replace(replace(coalesce(argument.annotation_prefix.value,
+    \"logs.grafana.com\"), \".\", \"_\"), \"/\", \"_\"), \"-\", \"_\")\n\t}\n\n\t//
+    find all pods\n\tdiscovery.kubernetes \"annotation_logs\" {\n\t\trole = \"pod\"\n\n\t\tnamespaces
+    {\n\t\t\tnames = coalesce(argument.namespaces.value, [])\n\t\t}\n\t}\n\n\t// filter
+    logs by kubernetes annotations\n\tdiscovery.relabel \"annotation_logs_filter\"
+    {\n\t\ttargets = discovery.kubernetes.annotation_logs.targets\n\n\t\t// allow
     pods to declare their logs to be ingested or not, the default is true\n\t\t//
     \  i.e. logs.grafana.com/ingest: false\n\t\trule {\n\t\t\taction        = \"keep\"\n\t\t\tsource_labels
     = [\n\t\t\t\t\"__meta_kubernetes_pod_annotation_\" + argument.__sd_annotation.value
@@ -760,15 +759,12 @@ data:
     set the job label to be namespace / friendly pod name\n\t\trule {\n\t\t\taction
     \       = \"replace\"\n\t\t\tsource_labels = [\n\t\t\t\t\"workload\",\n\t\t\t\t\"__meta_kubernetes_namespace\",\n\t\t\t]\n\t\t\tregex
     \       = \".+\\\\/(.+);(.+)\"\n\t\t\treplacement  = \"$2/$1\"\n\t\t\ttarget_label
-    = \"job\"\n\t\t}\n\t}\n\n\tdiscovery.relabel \"worker_logs\" {\n\t\ttargets =
-    discovery.relabel.log_annotations.output\n\n\t\t// set the __path__, this is automatically
-    translated as a label of filename (which should be dropped or normalized)\n\t\t//
-    DO NOT delete this line as it is needed to tail the pod logs on the node\n\t\trule
-    {\n\t\t\taction        = \"replace\"\n\t\t\tseparator     = \"/\"\n\t\t\tsource_labels
-    = [\n\t\t\t\t\"__meta_kubernetes_pod_uid\",\n\t\t\t\t\"__meta_kubernetes_pod_container_name\",\n\t\t\t]\n\t\t\treplacement
-    \ = \"/var/log/pods/*$1/*.log\"\n\t\t\ttarget_label = \"__path__\"\n\t\t}\n\n\t\t//
-    set the __host__\n\t\trule {\n\t\t\taction        = \"replace\"\n\t\t\tsource_labels
-    = [\"__meta_kubernetes_pod_node_name\"]\n\t\t\ttarget_label  = \"__host__\"\n\t\t}\n\n\t\t//
+    = \"job\"\n\t\t}\n\n\t\t// make all labels on the pod available to the pipeline
+    as labels,\n\t\t// they are omitted before write via labelallow unless explicitly
+    set\n\t\trule {\n\t\t\taction = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_label_(.+)\"\n\t\t}\n\n\t\t//
+    make all annotations on the pod available to the pipeline as labels,\n\t\t// they
+    are omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
+    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_annotation_(.+)\"\n\t\t}\n\n\t\t//
     as a result of kubernetes service discovery for pods, all of the meta data information
     is exposed in labels\n\t\t// __meta_kubernetes_pod_*, including __meta_kubernetes_pod_container_id
     which can be used to determine what\n\t\t// the pods container runtime is, docker
@@ -779,19 +775,11 @@ data:
     automatically determined, then drop the label from the loki.process stage.\n\t\t//
     set the container runtime as a label\n\t\trule {\n\t\t\taction        = \"replace\"\n\t\t\tsource_labels
     = [\"__meta_kubernetes_pod_container_id\"]\n\t\t\tregex         = \"^(\\\\w+):\\\\/\\\\/.+$\"\n\t\t\treplacement
-    \  = \"$1\"\n\t\t\ttarget_label  = \"tmp_container_runtime\"\n\t\t}\n\n\t\t//
-    make all labels on the pod available to the pipeline as labels,\n\t\t// they are
-    omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
-    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_label_(.+)\"\n\t\t}\n\n\t\t//
-    make all annotations on the pod available to the pipeline as labels,\n\t\t// they
-    are omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
-    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_annotation_(.+)\"\n\t\t}\n\t}\n\n\t//
-    find eligible files on the worker\n\tlocal.file_match \"pods\" {\n\t\tpath_targets
-    = discovery.relabel.worker_logs.output\n\t}\n\n\t// tail the files\n\tloki.source.file
-    \"pods\" {\n\t\ttargets    = local.file_match.pods.targets\n\t\tforward_to = [loki.process.parse.receiver]\n\t}\n\n\t//
-    parse the log based on the container runtime\n\tloki.process \"parse\" {\n\t\tforward_to
-    = argument.forward_to.value\n\t\t/*******************************************************************************\n
-    \    *                         Container Runtime Parsing\n     ********************************************************************************/\n\t\t//
+    \  = \"$1\"\n\t\t\ttarget_label  = \"tmp_container_runtime\"\n\t\t}\n\t}\n\n\tloki.source.kubernetes
+    \"lsd_kubernetes_logs\" {\n\t\ttargets    = discovery.relabel.annotation_logs_filter.output\n\t\tforward_to
+    = [loki.process.parse.receiver]\n\t}\n\n\t// parse the log based on the container
+    runtime\n\tloki.process \"parse\" {\n\t\tforward_to = argument.forward_to.value\n\t\t/*******************************************************************************\n\t\t*
+    \                        Container Runtime Parsing\n\t\t********************************************************************************/\n\t\t//
     if the label tmp_container_runtime from above is containerd parse using cri\n\t\tstage.match
     {\n\t\t\tselector = \"{tmp_container_runtime=\\\"containerd\\\"}\"\n\t\t\t// the
     cri processing stage extracts the following k/v pairs: log, stream, time, flags\n\t\t\tstage.cri
@@ -827,7 +815,7 @@ data:
     \"receiver\" {\n\t\tvalue = loki.process.keep_labels.receiver\n\t}\n}\n"
 kind: ConfigMap
 metadata:
-  name: alloy-modules-kubernetes-logs-dfhkhc94gt
+  name: alloy-modules-kubernetes-logs-d7c756mt2f
   namespace: monitoring-system
 ---
 apiVersion: v1
@@ -2096,7 +2084,7 @@ spec:
           items:
           - key: config.yaml
             path: config.yaml
-          name: loki-config-5h5fcktftg
+          name: loki-config-5468cb29k9
         name: config
       - configMap:
           name: loki-runtime-9599m5k6h2
@@ -2119,6 +2107,130 @@ spec:
       resources:
         requests:
           storage: 5Gi
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/instance: alloy
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/version: v1.0.0
+    helm.sh/chart: alloy-0.1.1
+  name: alloy
+  namespace: monitoring-system
+spec:
+  minReadySeconds: 10
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: alloy
+      app.kubernetes.io/name: alloy
+  serviceName: alloy
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: alloy
+        logs.agent.grafana.com/scrape: "true"
+        logs.agent.grafana.com/scrub-level: debug
+        profiles.grafana.com/cpu.port_name: http-metrics
+        profiles.grafana.com/cpu.scrape: "false"
+        profiles.grafana.com/goroutine.port_name: http-metrics
+        profiles.grafana.com/goroutine.scrape: "false"
+        profiles.grafana.com/memory.port_name: http-metrics
+        profiles.grafana.com/memory.scrape: "false"
+        pyroscope.io/service_name: alloy
+      labels:
+        app.kubernetes.io/instance: alloy
+        app.kubernetes.io/name: alloy
+    spec:
+      containers:
+      - args:
+        - run
+        - /etc/alloy/config.alloy
+        - --storage.path=/tmp/alloy
+        - --server.http.listen-addr=0.0.0.0:12345
+        - --server.http.ui-path-prefix=/
+        - --disable-reporting
+        - --cluster.enabled=true
+        - --cluster.join-addresses=alloy-cluster
+        - --stability.level=experimental
+        env:
+        - name: ALLOY_DEPLOY_MODE
+          value: helm
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        envFrom:
+        - secretRef:
+            name: alloy-env
+            optional: true
+        image: docker.io/grafana/alloy:v1.0.0
+        imagePullPolicy: IfNotPresent
+        name: alloy
+        ports:
+        - containerPort: 12345
+          name: http-metrics
+        - containerPort: 4317
+          name: grpc-otlp
+          protocol: TCP
+        - containerPort: 4318
+          name: http-otlp
+          protocol: TCP
+        - containerPort: 9411
+          name: zipkin
+          protocol: TCP
+        - containerPort: 6831
+          name: jaeger-compact
+          protocol: UDP
+        readinessProbe:
+          httpGet:
+            path: /-/ready
+            port: 12345
+            scheme: HTTP
+          initialDelaySeconds: 10
+          timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /etc/alloy
+          name: config
+        - mountPath: /etc/alloy/modules/kubernetes/metrics
+          name: modules-kubernetes-metrics
+        - mountPath: /etc/alloy/modules/kubernetes/integrations
+          name: modules-kubernetes-integrations
+        - mountPath: /etc/alloy/modules/kubernetes/logs
+          name: modules-kubernetes-logs
+        - mountPath: /etc/alloy/modules/kubernetes/traces
+          name: modules-kubernetes-traces
+        - mountPath: /etc/alloy/modules/kubernetes/profiles
+          name: modules-kubernetes-profiles
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: alloy
+      volumes:
+      - configMap:
+          name: alloy-config-6b695gbdm6
+        name: config
+      - configMap:
+          name: alloy-modules-kubernetes-metrics-tf9cd8b6bg
+        name: modules-kubernetes-metrics
+      - configMap:
+          name: alloy-modules-kubernetes-integrations-9k86fb8hkg
+        name: modules-kubernetes-integrations
+      - configMap:
+          name: alloy-modules-kubernetes-logs-d7c756mt2f
+        name: modules-kubernetes-logs
+      - configMap:
+          name: alloy-modules-kubernetes-traces-8mgm8th9m5
+        name: modules-kubernetes-traces
+      - configMap:
+          name: alloy-modules-kubernetes-profiles-66c27bc84g
+        name: modules-kubernetes-profiles
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -2322,135 +2434,6 @@ spec:
       app.kubernetes.io/component: all
       app.kubernetes.io/instance: pyroscope
       app.kubernetes.io/name: pyroscope
----
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  labels:
-    app.kubernetes.io/instance: alloy
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: alloy
-    app.kubernetes.io/version: v1.0.0
-    helm.sh/chart: alloy-0.1.1
-  name: alloy
-  namespace: monitoring-system
-spec:
-  minReadySeconds: 10
-  selector:
-    matchLabels:
-      app.kubernetes.io/instance: alloy
-      app.kubernetes.io/name: alloy
-  template:
-    metadata:
-      annotations:
-        kubectl.kubernetes.io/default-container: alloy
-        logs.agent.grafana.com/scrape: "true"
-        logs.agent.grafana.com/scrub-level: debug
-        profiles.grafana.com/cpu.port_name: http-metrics
-        profiles.grafana.com/cpu.scrape: "false"
-        profiles.grafana.com/goroutine.port_name: http-metrics
-        profiles.grafana.com/goroutine.scrape: "false"
-        profiles.grafana.com/memory.port_name: http-metrics
-        profiles.grafana.com/memory.scrape: "false"
-        pyroscope.io/service_name: alloy
-      labels:
-        app.kubernetes.io/instance: alloy
-        app.kubernetes.io/name: alloy
-    spec:
-      containers:
-      - args:
-        - run
-        - /etc/alloy/config.alloy
-        - --storage.path=/tmp/alloy
-        - --server.http.listen-addr=0.0.0.0:12345
-        - --server.http.ui-path-prefix=/
-        - --disable-reporting
-        - --cluster.enabled=true
-        - --cluster.join-addresses=alloy-cluster
-        - --stability.level=experimental
-        env:
-        - name: ALLOY_DEPLOY_MODE
-          value: helm
-        - name: HOSTNAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        envFrom:
-        - secretRef:
-            name: alloy-env
-            optional: true
-        image: docker.io/grafana/alloy:v1.0.0
-        imagePullPolicy: IfNotPresent
-        name: alloy
-        ports:
-        - containerPort: 12345
-          name: http-metrics
-        - containerPort: 4317
-          name: grpc-otlp
-          protocol: TCP
-        - containerPort: 4318
-          name: http-otlp
-          protocol: TCP
-        - containerPort: 9411
-          name: zipkin
-          protocol: TCP
-        - containerPort: 6831
-          name: jaeger-compact
-          protocol: UDP
-        readinessProbe:
-          httpGet:
-            path: /-/ready
-            port: 12345
-            scheme: HTTP
-          initialDelaySeconds: 10
-          timeoutSeconds: 1
-        volumeMounts:
-        - mountPath: /etc/alloy
-          name: config
-        - mountPath: /var/log
-          name: varlog
-          readOnly: true
-        - mountPath: /etc/alloy/modules/kubernetes/metrics
-          name: modules-kubernetes-metrics
-        - mountPath: /etc/alloy/modules/kubernetes/integrations
-          name: modules-kubernetes-integrations
-        - mountPath: /etc/alloy/modules/kubernetes/logs
-          name: modules-kubernetes-logs
-        - mountPath: /etc/alloy/modules/kubernetes/traces
-          name: modules-kubernetes-traces
-        - mountPath: /etc/alloy/modules/kubernetes/profiles
-          name: modules-kubernetes-profiles
-      dnsPolicy: ClusterFirst
-      nodeSelector:
-        kubernetes.io/os: linux
-      serviceAccountName: alloy
-      volumes:
-      - configMap:
-          name: alloy-config-6b695gbdm6
-        name: config
-      - hostPath:
-          path: /var/log
-        name: varlog
-      - configMap:
-          name: alloy-modules-kubernetes-metrics-tf9cd8b6bg
-        name: modules-kubernetes-metrics
-      - configMap:
-          name: alloy-modules-kubernetes-integrations-9k86fb8hkg
-        name: modules-kubernetes-integrations
-      - configMap:
-          name: alloy-modules-kubernetes-logs-dfhkhc94gt
-        name: modules-kubernetes-logs
-      - configMap:
-          name: alloy-modules-kubernetes-traces-8mgm8th9m5
-        name: modules-kubernetes-traces
-      - configMap:
-          name: alloy-modules-kubernetes-profiles-66c27bc84g
-        name: modules-kubernetes-profiles
-  updateStrategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 2
-    type: RollingUpdate
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/kubernetes/monolithic-mode/logs/k8s-all-in-one.yaml
+++ b/kubernetes/monolithic-mode/logs/k8s-all-in-one.yaml
@@ -311,8 +311,8 @@ data:
 
     storage_config:
       tsdb_shipper:
-        active_index_directory: /loki/index
-        cache_location: /loki/cache
+        active_index_directory: /var/loki/index
+        cache_location: /var/loki/cache
         index_gateway_client:
           server_address: "dns+loki.logging-system.svc.cluster.local:9095"
 
@@ -328,7 +328,7 @@ metadata:
     app.kubernetes.io/managed-by: Kustomize
     app.kubernetes.io/name: loki
     app.kubernetes.io/version: 3.0.0
-  name: loki-config-5h5fcktftg
+  name: loki-config-5468cb29k9
   namespace: logging-system
 ---
 apiVersion: v1
@@ -437,15 +437,14 @@ data:
     to look for targets in (default: [\\\"kube-system\\\"] is all namespaces)\"\n\t\toptional
     = true\n\t}\n\n\targument \"annotation_prefix\" {\n\t\tcomment  = \"The annotation_prefix
     to use (default: logs.grafana.com)\"\n\t\tdefault  = \"logs.grafana.com\"\n\t\toptional
-    = true\n\t}\n\n\t/*\n    Hidden Arguments\n    These arguments are used to set
-    reusable variables to avoid repeating logic\n  */\n\targument \"__sd_annotation\"
-    {\n\t\toptional = true\n\t\tcomment  = \"The logic is used to transform the annotation
-    argument into a valid label name by removing unsupported characters.\"\n\t\tdefault
-    \ = replace(replace(replace(coalesce(argument.annotation_prefix.value, \"logs.grafana.com\"),
-    \".\", \"_\"), \"/\", \"_\"), \"-\", \"_\")\n\t}\n\n\t// find all pods\n\tdiscovery.kubernetes
-    \"log_annotations\" {\n\t\trole = \"pod\"\n\n\t\tnamespaces {\n\t\t\tnames = coalesce(argument.namespaces.value,
-    [])\n\t\t}\n\t}\n\n\t// apply relabelings\n\tdiscovery.relabel \"log_annotations\"
-    {\n\t\ttargets = discovery.kubernetes.log_annotations.targets\n\n\t\t// allow
+    = true\n\t}\n\n\targument \"__sd_annotation\" {\n\t\toptional = true\n\t\tcomment
+    \ = \"The logic is used to transform the annotation argument into a valid label
+    name by removing unsupported characters.\"\n\t\tdefault  = replace(replace(replace(coalesce(argument.annotation_prefix.value,
+    \"logs.grafana.com\"), \".\", \"_\"), \"/\", \"_\"), \"-\", \"_\")\n\t}\n\n\t//
+    find all pods\n\tdiscovery.kubernetes \"annotation_logs\" {\n\t\trole = \"pod\"\n\n\t\tnamespaces
+    {\n\t\t\tnames = coalesce(argument.namespaces.value, [])\n\t\t}\n\t}\n\n\t// filter
+    logs by kubernetes annotations\n\tdiscovery.relabel \"annotation_logs_filter\"
+    {\n\t\ttargets = discovery.kubernetes.annotation_logs.targets\n\n\t\t// allow
     pods to declare their logs to be ingested or not, the default is true\n\t\t//
     \  i.e. logs.grafana.com/ingest: false\n\t\trule {\n\t\t\taction        = \"keep\"\n\t\t\tsource_labels
     = [\n\t\t\t\t\"__meta_kubernetes_pod_annotation_\" + argument.__sd_annotation.value
@@ -483,15 +482,12 @@ data:
     set the job label to be namespace / friendly pod name\n\t\trule {\n\t\t\taction
     \       = \"replace\"\n\t\t\tsource_labels = [\n\t\t\t\t\"workload\",\n\t\t\t\t\"__meta_kubernetes_namespace\",\n\t\t\t]\n\t\t\tregex
     \       = \".+\\\\/(.+);(.+)\"\n\t\t\treplacement  = \"$2/$1\"\n\t\t\ttarget_label
-    = \"job\"\n\t\t}\n\t}\n\n\tdiscovery.relabel \"worker_logs\" {\n\t\ttargets =
-    discovery.relabel.log_annotations.output\n\n\t\t// set the __path__, this is automatically
-    translated as a label of filename (which should be dropped or normalized)\n\t\t//
-    DO NOT delete this line as it is needed to tail the pod logs on the node\n\t\trule
-    {\n\t\t\taction        = \"replace\"\n\t\t\tseparator     = \"/\"\n\t\t\tsource_labels
-    = [\n\t\t\t\t\"__meta_kubernetes_pod_uid\",\n\t\t\t\t\"__meta_kubernetes_pod_container_name\",\n\t\t\t]\n\t\t\treplacement
-    \ = \"/var/log/pods/*$1/*.log\"\n\t\t\ttarget_label = \"__path__\"\n\t\t}\n\n\t\t//
-    set the __host__\n\t\trule {\n\t\t\taction        = \"replace\"\n\t\t\tsource_labels
-    = [\"__meta_kubernetes_pod_node_name\"]\n\t\t\ttarget_label  = \"__host__\"\n\t\t}\n\n\t\t//
+    = \"job\"\n\t\t}\n\n\t\t// make all labels on the pod available to the pipeline
+    as labels,\n\t\t// they are omitted before write via labelallow unless explicitly
+    set\n\t\trule {\n\t\t\taction = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_label_(.+)\"\n\t\t}\n\n\t\t//
+    make all annotations on the pod available to the pipeline as labels,\n\t\t// they
+    are omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
+    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_annotation_(.+)\"\n\t\t}\n\n\t\t//
     as a result of kubernetes service discovery for pods, all of the meta data information
     is exposed in labels\n\t\t// __meta_kubernetes_pod_*, including __meta_kubernetes_pod_container_id
     which can be used to determine what\n\t\t// the pods container runtime is, docker
@@ -502,19 +498,11 @@ data:
     automatically determined, then drop the label from the loki.process stage.\n\t\t//
     set the container runtime as a label\n\t\trule {\n\t\t\taction        = \"replace\"\n\t\t\tsource_labels
     = [\"__meta_kubernetes_pod_container_id\"]\n\t\t\tregex         = \"^(\\\\w+):\\\\/\\\\/.+$\"\n\t\t\treplacement
-    \  = \"$1\"\n\t\t\ttarget_label  = \"tmp_container_runtime\"\n\t\t}\n\n\t\t//
-    make all labels on the pod available to the pipeline as labels,\n\t\t// they are
-    omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
-    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_label_(.+)\"\n\t\t}\n\n\t\t//
-    make all annotations on the pod available to the pipeline as labels,\n\t\t// they
-    are omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
-    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_annotation_(.+)\"\n\t\t}\n\t}\n\n\t//
-    find eligible files on the worker\n\tlocal.file_match \"pods\" {\n\t\tpath_targets
-    = discovery.relabel.worker_logs.output\n\t}\n\n\t// tail the files\n\tloki.source.file
-    \"pods\" {\n\t\ttargets    = local.file_match.pods.targets\n\t\tforward_to = [loki.process.parse.receiver]\n\t}\n\n\t//
-    parse the log based on the container runtime\n\tloki.process \"parse\" {\n\t\tforward_to
-    = argument.forward_to.value\n\t\t/*******************************************************************************\n
-    \    *                         Container Runtime Parsing\n     ********************************************************************************/\n\t\t//
+    \  = \"$1\"\n\t\t\ttarget_label  = \"tmp_container_runtime\"\n\t\t}\n\t}\n\n\tloki.source.kubernetes
+    \"lsd_kubernetes_logs\" {\n\t\ttargets    = discovery.relabel.annotation_logs_filter.output\n\t\tforward_to
+    = [loki.process.parse.receiver]\n\t}\n\n\t// parse the log based on the container
+    runtime\n\tloki.process \"parse\" {\n\t\tforward_to = argument.forward_to.value\n\t\t/*******************************************************************************\n\t\t*
+    \                        Container Runtime Parsing\n\t\t********************************************************************************/\n\t\t//
     if the label tmp_container_runtime from above is containerd parse using cri\n\t\tstage.match
     {\n\t\t\tselector = \"{tmp_container_runtime=\\\"containerd\\\"}\"\n\t\t\t// the
     cri processing stage extracts the following k/v pairs: log, stream, time, flags\n\t\t\tstage.cri
@@ -550,7 +538,7 @@ data:
     \"receiver\" {\n\t\tvalue = loki.process.keep_labels.receiver\n\t}\n}\n"
 kind: ConfigMap
 metadata:
-  name: alloy-modules-kubernetes-logs-dfhkhc94gt
+  name: alloy-modules-kubernetes-logs-d7c756mt2f
   namespace: monitoring-system
 ---
 apiVersion: v1
@@ -1477,7 +1465,7 @@ spec:
           items:
           - key: config.yaml
             path: config.yaml
-          name: loki-config-5h5fcktftg
+          name: loki-config-5468cb29k9
         name: config
       - configMap:
           name: loki-runtime-9599m5k6h2
@@ -1502,7 +1490,7 @@ spec:
           storage: 5Gi
 ---
 apiVersion: apps/v1
-kind: DaemonSet
+kind: StatefulSet
 metadata:
   labels:
     app.kubernetes.io/instance: alloy
@@ -1514,10 +1502,16 @@ metadata:
   namespace: monitoring-system
 spec:
   minReadySeconds: 10
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  podManagementPolicy: Parallel
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: alloy
       app.kubernetes.io/name: alloy
+  serviceName: alloy
   template:
     metadata:
       annotations:
@@ -1585,9 +1579,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/alloy
           name: config
-        - mountPath: /var/log
-          name: varlog
-          readOnly: true
         - mountPath: /etc/alloy/modules/kubernetes/metrics
           name: modules-kubernetes-metrics
         - mountPath: /etc/alloy/modules/kubernetes/integrations
@@ -1606,9 +1597,6 @@ spec:
       - configMap:
           name: alloy-config-8t9d8htff7
         name: config
-      - hostPath:
-          path: /var/log
-        name: varlog
       - configMap:
           name: alloy-modules-kubernetes-metrics-tf9cd8b6bg
         name: modules-kubernetes-metrics
@@ -1616,7 +1604,7 @@ spec:
           name: alloy-modules-kubernetes-integrations-9k86fb8hkg
         name: modules-kubernetes-integrations
       - configMap:
-          name: alloy-modules-kubernetes-logs-dfhkhc94gt
+          name: alloy-modules-kubernetes-logs-d7c756mt2f
         name: modules-kubernetes-logs
       - configMap:
           name: alloy-modules-kubernetes-traces-8mgm8th9m5
@@ -1624,11 +1612,6 @@ spec:
       - configMap:
           name: alloy-modules-kubernetes-profiles-66c27bc84g
         name: modules-kubernetes-profiles
-  updateStrategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 2
-    type: RollingUpdate
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/kubernetes/monolithic-mode/logs/loki/configs/loki.yaml
+++ b/kubernetes/monolithic-mode/logs/loki/configs/loki.yaml
@@ -99,8 +99,8 @@ schema_config:
 
 storage_config:
   tsdb_shipper:
-    active_index_directory: /loki/index
-    cache_location: /loki/cache
+    active_index_directory: /var/loki/index
+    cache_location: /var/loki/cache
     index_gateway_client:
       server_address: "dns+loki.logging-system.svc.cluster.local:9095"
 

--- a/kubernetes/monolithic-mode/metrics/k8s-all-in-one.yaml
+++ b/kubernetes/monolithic-mode/metrics/k8s-all-in-one.yaml
@@ -222,15 +222,14 @@ data:
     to look for targets in (default: [\\\"kube-system\\\"] is all namespaces)\"\n\t\toptional
     = true\n\t}\n\n\targument \"annotation_prefix\" {\n\t\tcomment  = \"The annotation_prefix
     to use (default: logs.grafana.com)\"\n\t\tdefault  = \"logs.grafana.com\"\n\t\toptional
-    = true\n\t}\n\n\t/*\n    Hidden Arguments\n    These arguments are used to set
-    reusable variables to avoid repeating logic\n  */\n\targument \"__sd_annotation\"
-    {\n\t\toptional = true\n\t\tcomment  = \"The logic is used to transform the annotation
-    argument into a valid label name by removing unsupported characters.\"\n\t\tdefault
-    \ = replace(replace(replace(coalesce(argument.annotation_prefix.value, \"logs.grafana.com\"),
-    \".\", \"_\"), \"/\", \"_\"), \"-\", \"_\")\n\t}\n\n\t// find all pods\n\tdiscovery.kubernetes
-    \"log_annotations\" {\n\t\trole = \"pod\"\n\n\t\tnamespaces {\n\t\t\tnames = coalesce(argument.namespaces.value,
-    [])\n\t\t}\n\t}\n\n\t// apply relabelings\n\tdiscovery.relabel \"log_annotations\"
-    {\n\t\ttargets = discovery.kubernetes.log_annotations.targets\n\n\t\t// allow
+    = true\n\t}\n\n\targument \"__sd_annotation\" {\n\t\toptional = true\n\t\tcomment
+    \ = \"The logic is used to transform the annotation argument into a valid label
+    name by removing unsupported characters.\"\n\t\tdefault  = replace(replace(replace(coalesce(argument.annotation_prefix.value,
+    \"logs.grafana.com\"), \".\", \"_\"), \"/\", \"_\"), \"-\", \"_\")\n\t}\n\n\t//
+    find all pods\n\tdiscovery.kubernetes \"annotation_logs\" {\n\t\trole = \"pod\"\n\n\t\tnamespaces
+    {\n\t\t\tnames = coalesce(argument.namespaces.value, [])\n\t\t}\n\t}\n\n\t// filter
+    logs by kubernetes annotations\n\tdiscovery.relabel \"annotation_logs_filter\"
+    {\n\t\ttargets = discovery.kubernetes.annotation_logs.targets\n\n\t\t// allow
     pods to declare their logs to be ingested or not, the default is true\n\t\t//
     \  i.e. logs.grafana.com/ingest: false\n\t\trule {\n\t\t\taction        = \"keep\"\n\t\t\tsource_labels
     = [\n\t\t\t\t\"__meta_kubernetes_pod_annotation_\" + argument.__sd_annotation.value
@@ -268,15 +267,12 @@ data:
     set the job label to be namespace / friendly pod name\n\t\trule {\n\t\t\taction
     \       = \"replace\"\n\t\t\tsource_labels = [\n\t\t\t\t\"workload\",\n\t\t\t\t\"__meta_kubernetes_namespace\",\n\t\t\t]\n\t\t\tregex
     \       = \".+\\\\/(.+);(.+)\"\n\t\t\treplacement  = \"$2/$1\"\n\t\t\ttarget_label
-    = \"job\"\n\t\t}\n\t}\n\n\tdiscovery.relabel \"worker_logs\" {\n\t\ttargets =
-    discovery.relabel.log_annotations.output\n\n\t\t// set the __path__, this is automatically
-    translated as a label of filename (which should be dropped or normalized)\n\t\t//
-    DO NOT delete this line as it is needed to tail the pod logs on the node\n\t\trule
-    {\n\t\t\taction        = \"replace\"\n\t\t\tseparator     = \"/\"\n\t\t\tsource_labels
-    = [\n\t\t\t\t\"__meta_kubernetes_pod_uid\",\n\t\t\t\t\"__meta_kubernetes_pod_container_name\",\n\t\t\t]\n\t\t\treplacement
-    \ = \"/var/log/pods/*$1/*.log\"\n\t\t\ttarget_label = \"__path__\"\n\t\t}\n\n\t\t//
-    set the __host__\n\t\trule {\n\t\t\taction        = \"replace\"\n\t\t\tsource_labels
-    = [\"__meta_kubernetes_pod_node_name\"]\n\t\t\ttarget_label  = \"__host__\"\n\t\t}\n\n\t\t//
+    = \"job\"\n\t\t}\n\n\t\t// make all labels on the pod available to the pipeline
+    as labels,\n\t\t// they are omitted before write via labelallow unless explicitly
+    set\n\t\trule {\n\t\t\taction = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_label_(.+)\"\n\t\t}\n\n\t\t//
+    make all annotations on the pod available to the pipeline as labels,\n\t\t// they
+    are omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
+    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_annotation_(.+)\"\n\t\t}\n\n\t\t//
     as a result of kubernetes service discovery for pods, all of the meta data information
     is exposed in labels\n\t\t// __meta_kubernetes_pod_*, including __meta_kubernetes_pod_container_id
     which can be used to determine what\n\t\t// the pods container runtime is, docker
@@ -287,19 +283,11 @@ data:
     automatically determined, then drop the label from the loki.process stage.\n\t\t//
     set the container runtime as a label\n\t\trule {\n\t\t\taction        = \"replace\"\n\t\t\tsource_labels
     = [\"__meta_kubernetes_pod_container_id\"]\n\t\t\tregex         = \"^(\\\\w+):\\\\/\\\\/.+$\"\n\t\t\treplacement
-    \  = \"$1\"\n\t\t\ttarget_label  = \"tmp_container_runtime\"\n\t\t}\n\n\t\t//
-    make all labels on the pod available to the pipeline as labels,\n\t\t// they are
-    omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
-    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_label_(.+)\"\n\t\t}\n\n\t\t//
-    make all annotations on the pod available to the pipeline as labels,\n\t\t// they
-    are omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
-    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_annotation_(.+)\"\n\t\t}\n\t}\n\n\t//
-    find eligible files on the worker\n\tlocal.file_match \"pods\" {\n\t\tpath_targets
-    = discovery.relabel.worker_logs.output\n\t}\n\n\t// tail the files\n\tloki.source.file
-    \"pods\" {\n\t\ttargets    = local.file_match.pods.targets\n\t\tforward_to = [loki.process.parse.receiver]\n\t}\n\n\t//
-    parse the log based on the container runtime\n\tloki.process \"parse\" {\n\t\tforward_to
-    = argument.forward_to.value\n\t\t/*******************************************************************************\n
-    \    *                         Container Runtime Parsing\n     ********************************************************************************/\n\t\t//
+    \  = \"$1\"\n\t\t\ttarget_label  = \"tmp_container_runtime\"\n\t\t}\n\t}\n\n\tloki.source.kubernetes
+    \"lsd_kubernetes_logs\" {\n\t\ttargets    = discovery.relabel.annotation_logs_filter.output\n\t\tforward_to
+    = [loki.process.parse.receiver]\n\t}\n\n\t// parse the log based on the container
+    runtime\n\tloki.process \"parse\" {\n\t\tforward_to = argument.forward_to.value\n\t\t/*******************************************************************************\n\t\t*
+    \                        Container Runtime Parsing\n\t\t********************************************************************************/\n\t\t//
     if the label tmp_container_runtime from above is containerd parse using cri\n\t\tstage.match
     {\n\t\t\tselector = \"{tmp_container_runtime=\\\"containerd\\\"}\"\n\t\t\t// the
     cri processing stage extracts the following k/v pairs: log, stream, time, flags\n\t\t\tstage.cri
@@ -335,7 +323,7 @@ data:
     \"receiver\" {\n\t\tvalue = loki.process.keep_labels.receiver\n\t}\n}\n"
 kind: ConfigMap
 metadata:
-  name: alloy-modules-kubernetes-logs-dfhkhc94gt
+  name: alloy-modules-kubernetes-logs-d7c756mt2f
   namespace: monitoring-system
 ---
 apiVersion: v1
@@ -1080,7 +1068,7 @@ spec:
         name: storage
 ---
 apiVersion: apps/v1
-kind: DaemonSet
+kind: StatefulSet
 metadata:
   labels:
     app.kubernetes.io/instance: alloy
@@ -1092,10 +1080,16 @@ metadata:
   namespace: monitoring-system
 spec:
   minReadySeconds: 10
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  podManagementPolicy: Parallel
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: alloy
       app.kubernetes.io/name: alloy
+  serviceName: alloy
   template:
     metadata:
       annotations:
@@ -1163,9 +1157,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/alloy
           name: config
-        - mountPath: /var/log
-          name: varlog
-          readOnly: true
         - mountPath: /etc/alloy/modules/kubernetes/metrics
           name: modules-kubernetes-metrics
         - mountPath: /etc/alloy/modules/kubernetes/integrations
@@ -1184,9 +1175,6 @@ spec:
       - configMap:
           name: alloy-config-m6chdfm49m
         name: config
-      - hostPath:
-          path: /var/log
-        name: varlog
       - configMap:
           name: alloy-modules-kubernetes-metrics-tf9cd8b6bg
         name: modules-kubernetes-metrics
@@ -1194,7 +1182,7 @@ spec:
           name: alloy-modules-kubernetes-integrations-9k86fb8hkg
         name: modules-kubernetes-integrations
       - configMap:
-          name: alloy-modules-kubernetes-logs-dfhkhc94gt
+          name: alloy-modules-kubernetes-logs-d7c756mt2f
         name: modules-kubernetes-logs
       - configMap:
           name: alloy-modules-kubernetes-traces-8mgm8th9m5
@@ -1202,11 +1190,6 @@ spec:
       - configMap:
           name: alloy-modules-kubernetes-profiles-66c27bc84g
         name: modules-kubernetes-profiles
-  updateStrategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 2
-    type: RollingUpdate
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/kubernetes/monolithic-mode/profiles/k8s-all-in-one.yaml
+++ b/kubernetes/monolithic-mode/profiles/k8s-all-in-one.yaml
@@ -287,15 +287,14 @@ data:
     to look for targets in (default: [\\\"kube-system\\\"] is all namespaces)\"\n\t\toptional
     = true\n\t}\n\n\targument \"annotation_prefix\" {\n\t\tcomment  = \"The annotation_prefix
     to use (default: logs.grafana.com)\"\n\t\tdefault  = \"logs.grafana.com\"\n\t\toptional
-    = true\n\t}\n\n\t/*\n    Hidden Arguments\n    These arguments are used to set
-    reusable variables to avoid repeating logic\n  */\n\targument \"__sd_annotation\"
-    {\n\t\toptional = true\n\t\tcomment  = \"The logic is used to transform the annotation
-    argument into a valid label name by removing unsupported characters.\"\n\t\tdefault
-    \ = replace(replace(replace(coalesce(argument.annotation_prefix.value, \"logs.grafana.com\"),
-    \".\", \"_\"), \"/\", \"_\"), \"-\", \"_\")\n\t}\n\n\t// find all pods\n\tdiscovery.kubernetes
-    \"log_annotations\" {\n\t\trole = \"pod\"\n\n\t\tnamespaces {\n\t\t\tnames = coalesce(argument.namespaces.value,
-    [])\n\t\t}\n\t}\n\n\t// apply relabelings\n\tdiscovery.relabel \"log_annotations\"
-    {\n\t\ttargets = discovery.kubernetes.log_annotations.targets\n\n\t\t// allow
+    = true\n\t}\n\n\targument \"__sd_annotation\" {\n\t\toptional = true\n\t\tcomment
+    \ = \"The logic is used to transform the annotation argument into a valid label
+    name by removing unsupported characters.\"\n\t\tdefault  = replace(replace(replace(coalesce(argument.annotation_prefix.value,
+    \"logs.grafana.com\"), \".\", \"_\"), \"/\", \"_\"), \"-\", \"_\")\n\t}\n\n\t//
+    find all pods\n\tdiscovery.kubernetes \"annotation_logs\" {\n\t\trole = \"pod\"\n\n\t\tnamespaces
+    {\n\t\t\tnames = coalesce(argument.namespaces.value, [])\n\t\t}\n\t}\n\n\t// filter
+    logs by kubernetes annotations\n\tdiscovery.relabel \"annotation_logs_filter\"
+    {\n\t\ttargets = discovery.kubernetes.annotation_logs.targets\n\n\t\t// allow
     pods to declare their logs to be ingested or not, the default is true\n\t\t//
     \  i.e. logs.grafana.com/ingest: false\n\t\trule {\n\t\t\taction        = \"keep\"\n\t\t\tsource_labels
     = [\n\t\t\t\t\"__meta_kubernetes_pod_annotation_\" + argument.__sd_annotation.value
@@ -333,15 +332,12 @@ data:
     set the job label to be namespace / friendly pod name\n\t\trule {\n\t\t\taction
     \       = \"replace\"\n\t\t\tsource_labels = [\n\t\t\t\t\"workload\",\n\t\t\t\t\"__meta_kubernetes_namespace\",\n\t\t\t]\n\t\t\tregex
     \       = \".+\\\\/(.+);(.+)\"\n\t\t\treplacement  = \"$2/$1\"\n\t\t\ttarget_label
-    = \"job\"\n\t\t}\n\t}\n\n\tdiscovery.relabel \"worker_logs\" {\n\t\ttargets =
-    discovery.relabel.log_annotations.output\n\n\t\t// set the __path__, this is automatically
-    translated as a label of filename (which should be dropped or normalized)\n\t\t//
-    DO NOT delete this line as it is needed to tail the pod logs on the node\n\t\trule
-    {\n\t\t\taction        = \"replace\"\n\t\t\tseparator     = \"/\"\n\t\t\tsource_labels
-    = [\n\t\t\t\t\"__meta_kubernetes_pod_uid\",\n\t\t\t\t\"__meta_kubernetes_pod_container_name\",\n\t\t\t]\n\t\t\treplacement
-    \ = \"/var/log/pods/*$1/*.log\"\n\t\t\ttarget_label = \"__path__\"\n\t\t}\n\n\t\t//
-    set the __host__\n\t\trule {\n\t\t\taction        = \"replace\"\n\t\t\tsource_labels
-    = [\"__meta_kubernetes_pod_node_name\"]\n\t\t\ttarget_label  = \"__host__\"\n\t\t}\n\n\t\t//
+    = \"job\"\n\t\t}\n\n\t\t// make all labels on the pod available to the pipeline
+    as labels,\n\t\t// they are omitted before write via labelallow unless explicitly
+    set\n\t\trule {\n\t\t\taction = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_label_(.+)\"\n\t\t}\n\n\t\t//
+    make all annotations on the pod available to the pipeline as labels,\n\t\t// they
+    are omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
+    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_annotation_(.+)\"\n\t\t}\n\n\t\t//
     as a result of kubernetes service discovery for pods, all of the meta data information
     is exposed in labels\n\t\t// __meta_kubernetes_pod_*, including __meta_kubernetes_pod_container_id
     which can be used to determine what\n\t\t// the pods container runtime is, docker
@@ -352,19 +348,11 @@ data:
     automatically determined, then drop the label from the loki.process stage.\n\t\t//
     set the container runtime as a label\n\t\trule {\n\t\t\taction        = \"replace\"\n\t\t\tsource_labels
     = [\"__meta_kubernetes_pod_container_id\"]\n\t\t\tregex         = \"^(\\\\w+):\\\\/\\\\/.+$\"\n\t\t\treplacement
-    \  = \"$1\"\n\t\t\ttarget_label  = \"tmp_container_runtime\"\n\t\t}\n\n\t\t//
-    make all labels on the pod available to the pipeline as labels,\n\t\t// they are
-    omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
-    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_label_(.+)\"\n\t\t}\n\n\t\t//
-    make all annotations on the pod available to the pipeline as labels,\n\t\t// they
-    are omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
-    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_annotation_(.+)\"\n\t\t}\n\t}\n\n\t//
-    find eligible files on the worker\n\tlocal.file_match \"pods\" {\n\t\tpath_targets
-    = discovery.relabel.worker_logs.output\n\t}\n\n\t// tail the files\n\tloki.source.file
-    \"pods\" {\n\t\ttargets    = local.file_match.pods.targets\n\t\tforward_to = [loki.process.parse.receiver]\n\t}\n\n\t//
-    parse the log based on the container runtime\n\tloki.process \"parse\" {\n\t\tforward_to
-    = argument.forward_to.value\n\t\t/*******************************************************************************\n
-    \    *                         Container Runtime Parsing\n     ********************************************************************************/\n\t\t//
+    \  = \"$1\"\n\t\t\ttarget_label  = \"tmp_container_runtime\"\n\t\t}\n\t}\n\n\tloki.source.kubernetes
+    \"lsd_kubernetes_logs\" {\n\t\ttargets    = discovery.relabel.annotation_logs_filter.output\n\t\tforward_to
+    = [loki.process.parse.receiver]\n\t}\n\n\t// parse the log based on the container
+    runtime\n\tloki.process \"parse\" {\n\t\tforward_to = argument.forward_to.value\n\t\t/*******************************************************************************\n\t\t*
+    \                        Container Runtime Parsing\n\t\t********************************************************************************/\n\t\t//
     if the label tmp_container_runtime from above is containerd parse using cri\n\t\tstage.match
     {\n\t\t\tselector = \"{tmp_container_runtime=\\\"containerd\\\"}\"\n\t\t\t// the
     cri processing stage extracts the following k/v pairs: log, stream, time, flags\n\t\t\tstage.cri
@@ -400,7 +388,7 @@ data:
     \"receiver\" {\n\t\tvalue = loki.process.keep_labels.receiver\n\t}\n}\n"
 kind: ConfigMap
 metadata:
-  name: alloy-modules-kubernetes-logs-dfhkhc94gt
+  name: alloy-modules-kubernetes-logs-d7c756mt2f
   namespace: monitoring-system
 ---
 apiVersion: v1
@@ -1279,6 +1267,130 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
+    app.kubernetes.io/instance: alloy
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/version: v1.0.0
+    helm.sh/chart: alloy-0.1.1
+  name: alloy
+  namespace: monitoring-system
+spec:
+  minReadySeconds: 10
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: alloy
+      app.kubernetes.io/name: alloy
+  serviceName: alloy
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: alloy
+        logs.agent.grafana.com/scrape: "true"
+        logs.agent.grafana.com/scrub-level: debug
+        profiles.grafana.com/cpu.port_name: http-metrics
+        profiles.grafana.com/cpu.scrape: "false"
+        profiles.grafana.com/goroutine.port_name: http-metrics
+        profiles.grafana.com/goroutine.scrape: "false"
+        profiles.grafana.com/memory.port_name: http-metrics
+        profiles.grafana.com/memory.scrape: "false"
+        pyroscope.io/service_name: alloy
+      labels:
+        app.kubernetes.io/instance: alloy
+        app.kubernetes.io/name: alloy
+    spec:
+      containers:
+      - args:
+        - run
+        - /etc/alloy/config.alloy
+        - --storage.path=/tmp/alloy
+        - --server.http.listen-addr=0.0.0.0:12345
+        - --server.http.ui-path-prefix=/
+        - --disable-reporting
+        - --cluster.enabled=true
+        - --cluster.join-addresses=alloy-cluster
+        - --stability.level=experimental
+        env:
+        - name: ALLOY_DEPLOY_MODE
+          value: helm
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        envFrom:
+        - secretRef:
+            name: alloy-env
+            optional: true
+        image: docker.io/grafana/alloy:v1.0.0
+        imagePullPolicy: IfNotPresent
+        name: alloy
+        ports:
+        - containerPort: 12345
+          name: http-metrics
+        - containerPort: 4317
+          name: grpc-otlp
+          protocol: TCP
+        - containerPort: 4318
+          name: http-otlp
+          protocol: TCP
+        - containerPort: 9411
+          name: zipkin
+          protocol: TCP
+        - containerPort: 6831
+          name: jaeger-compact
+          protocol: UDP
+        readinessProbe:
+          httpGet:
+            path: /-/ready
+            port: 12345
+            scheme: HTTP
+          initialDelaySeconds: 10
+          timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /etc/alloy
+          name: config
+        - mountPath: /etc/alloy/modules/kubernetes/metrics
+          name: modules-kubernetes-metrics
+        - mountPath: /etc/alloy/modules/kubernetes/integrations
+          name: modules-kubernetes-integrations
+        - mountPath: /etc/alloy/modules/kubernetes/logs
+          name: modules-kubernetes-logs
+        - mountPath: /etc/alloy/modules/kubernetes/traces
+          name: modules-kubernetes-traces
+        - mountPath: /etc/alloy/modules/kubernetes/profiles
+          name: modules-kubernetes-profiles
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: alloy
+      volumes:
+      - configMap:
+          name: alloy-config-5k62427t46
+        name: config
+      - configMap:
+          name: alloy-modules-kubernetes-metrics-tf9cd8b6bg
+        name: modules-kubernetes-metrics
+      - configMap:
+          name: alloy-modules-kubernetes-integrations-9k86fb8hkg
+        name: modules-kubernetes-integrations
+      - configMap:
+          name: alloy-modules-kubernetes-logs-d7c756mt2f
+        name: modules-kubernetes-logs
+      - configMap:
+          name: alloy-modules-kubernetes-traces-8mgm8th9m5
+        name: modules-kubernetes-traces
+      - configMap:
+          name: alloy-modules-kubernetes-profiles-66c27bc84g
+        name: modules-kubernetes-profiles
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
     app.kubernetes.io/component: all
     app.kubernetes.io/instance: pyroscope
     app.kubernetes.io/managed-by: Helm
@@ -1387,135 +1499,6 @@ spec:
       app.kubernetes.io/component: all
       app.kubernetes.io/instance: pyroscope
       app.kubernetes.io/name: pyroscope
----
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  labels:
-    app.kubernetes.io/instance: alloy
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: alloy
-    app.kubernetes.io/version: v1.0.0
-    helm.sh/chart: alloy-0.1.1
-  name: alloy
-  namespace: monitoring-system
-spec:
-  minReadySeconds: 10
-  selector:
-    matchLabels:
-      app.kubernetes.io/instance: alloy
-      app.kubernetes.io/name: alloy
-  template:
-    metadata:
-      annotations:
-        kubectl.kubernetes.io/default-container: alloy
-        logs.agent.grafana.com/scrape: "true"
-        logs.agent.grafana.com/scrub-level: debug
-        profiles.grafana.com/cpu.port_name: http-metrics
-        profiles.grafana.com/cpu.scrape: "false"
-        profiles.grafana.com/goroutine.port_name: http-metrics
-        profiles.grafana.com/goroutine.scrape: "false"
-        profiles.grafana.com/memory.port_name: http-metrics
-        profiles.grafana.com/memory.scrape: "false"
-        pyroscope.io/service_name: alloy
-      labels:
-        app.kubernetes.io/instance: alloy
-        app.kubernetes.io/name: alloy
-    spec:
-      containers:
-      - args:
-        - run
-        - /etc/alloy/config.alloy
-        - --storage.path=/tmp/alloy
-        - --server.http.listen-addr=0.0.0.0:12345
-        - --server.http.ui-path-prefix=/
-        - --disable-reporting
-        - --cluster.enabled=true
-        - --cluster.join-addresses=alloy-cluster
-        - --stability.level=experimental
-        env:
-        - name: ALLOY_DEPLOY_MODE
-          value: helm
-        - name: HOSTNAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        envFrom:
-        - secretRef:
-            name: alloy-env
-            optional: true
-        image: docker.io/grafana/alloy:v1.0.0
-        imagePullPolicy: IfNotPresent
-        name: alloy
-        ports:
-        - containerPort: 12345
-          name: http-metrics
-        - containerPort: 4317
-          name: grpc-otlp
-          protocol: TCP
-        - containerPort: 4318
-          name: http-otlp
-          protocol: TCP
-        - containerPort: 9411
-          name: zipkin
-          protocol: TCP
-        - containerPort: 6831
-          name: jaeger-compact
-          protocol: UDP
-        readinessProbe:
-          httpGet:
-            path: /-/ready
-            port: 12345
-            scheme: HTTP
-          initialDelaySeconds: 10
-          timeoutSeconds: 1
-        volumeMounts:
-        - mountPath: /etc/alloy
-          name: config
-        - mountPath: /var/log
-          name: varlog
-          readOnly: true
-        - mountPath: /etc/alloy/modules/kubernetes/metrics
-          name: modules-kubernetes-metrics
-        - mountPath: /etc/alloy/modules/kubernetes/integrations
-          name: modules-kubernetes-integrations
-        - mountPath: /etc/alloy/modules/kubernetes/logs
-          name: modules-kubernetes-logs
-        - mountPath: /etc/alloy/modules/kubernetes/traces
-          name: modules-kubernetes-traces
-        - mountPath: /etc/alloy/modules/kubernetes/profiles
-          name: modules-kubernetes-profiles
-      dnsPolicy: ClusterFirst
-      nodeSelector:
-        kubernetes.io/os: linux
-      serviceAccountName: alloy
-      volumes:
-      - configMap:
-          name: alloy-config-5k62427t46
-        name: config
-      - hostPath:
-          path: /var/log
-        name: varlog
-      - configMap:
-          name: alloy-modules-kubernetes-metrics-tf9cd8b6bg
-        name: modules-kubernetes-metrics
-      - configMap:
-          name: alloy-modules-kubernetes-integrations-9k86fb8hkg
-        name: modules-kubernetes-integrations
-      - configMap:
-          name: alloy-modules-kubernetes-logs-dfhkhc94gt
-        name: modules-kubernetes-logs
-      - configMap:
-          name: alloy-modules-kubernetes-traces-8mgm8th9m5
-        name: modules-kubernetes-traces
-      - configMap:
-          name: alloy-modules-kubernetes-profiles-66c27bc84g
-        name: modules-kubernetes-profiles
-  updateStrategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 2
-    type: RollingUpdate
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/kubernetes/monolithic-mode/traces/k8s-all-in-one.yaml
+++ b/kubernetes/monolithic-mode/traces/k8s-all-in-one.yaml
@@ -297,15 +297,14 @@ data:
     to look for targets in (default: [\\\"kube-system\\\"] is all namespaces)\"\n\t\toptional
     = true\n\t}\n\n\targument \"annotation_prefix\" {\n\t\tcomment  = \"The annotation_prefix
     to use (default: logs.grafana.com)\"\n\t\tdefault  = \"logs.grafana.com\"\n\t\toptional
-    = true\n\t}\n\n\t/*\n    Hidden Arguments\n    These arguments are used to set
-    reusable variables to avoid repeating logic\n  */\n\targument \"__sd_annotation\"
-    {\n\t\toptional = true\n\t\tcomment  = \"The logic is used to transform the annotation
-    argument into a valid label name by removing unsupported characters.\"\n\t\tdefault
-    \ = replace(replace(replace(coalesce(argument.annotation_prefix.value, \"logs.grafana.com\"),
-    \".\", \"_\"), \"/\", \"_\"), \"-\", \"_\")\n\t}\n\n\t// find all pods\n\tdiscovery.kubernetes
-    \"log_annotations\" {\n\t\trole = \"pod\"\n\n\t\tnamespaces {\n\t\t\tnames = coalesce(argument.namespaces.value,
-    [])\n\t\t}\n\t}\n\n\t// apply relabelings\n\tdiscovery.relabel \"log_annotations\"
-    {\n\t\ttargets = discovery.kubernetes.log_annotations.targets\n\n\t\t// allow
+    = true\n\t}\n\n\targument \"__sd_annotation\" {\n\t\toptional = true\n\t\tcomment
+    \ = \"The logic is used to transform the annotation argument into a valid label
+    name by removing unsupported characters.\"\n\t\tdefault  = replace(replace(replace(coalesce(argument.annotation_prefix.value,
+    \"logs.grafana.com\"), \".\", \"_\"), \"/\", \"_\"), \"-\", \"_\")\n\t}\n\n\t//
+    find all pods\n\tdiscovery.kubernetes \"annotation_logs\" {\n\t\trole = \"pod\"\n\n\t\tnamespaces
+    {\n\t\t\tnames = coalesce(argument.namespaces.value, [])\n\t\t}\n\t}\n\n\t// filter
+    logs by kubernetes annotations\n\tdiscovery.relabel \"annotation_logs_filter\"
+    {\n\t\ttargets = discovery.kubernetes.annotation_logs.targets\n\n\t\t// allow
     pods to declare their logs to be ingested or not, the default is true\n\t\t//
     \  i.e. logs.grafana.com/ingest: false\n\t\trule {\n\t\t\taction        = \"keep\"\n\t\t\tsource_labels
     = [\n\t\t\t\t\"__meta_kubernetes_pod_annotation_\" + argument.__sd_annotation.value
@@ -343,15 +342,12 @@ data:
     set the job label to be namespace / friendly pod name\n\t\trule {\n\t\t\taction
     \       = \"replace\"\n\t\t\tsource_labels = [\n\t\t\t\t\"workload\",\n\t\t\t\t\"__meta_kubernetes_namespace\",\n\t\t\t]\n\t\t\tregex
     \       = \".+\\\\/(.+);(.+)\"\n\t\t\treplacement  = \"$2/$1\"\n\t\t\ttarget_label
-    = \"job\"\n\t\t}\n\t}\n\n\tdiscovery.relabel \"worker_logs\" {\n\t\ttargets =
-    discovery.relabel.log_annotations.output\n\n\t\t// set the __path__, this is automatically
-    translated as a label of filename (which should be dropped or normalized)\n\t\t//
-    DO NOT delete this line as it is needed to tail the pod logs on the node\n\t\trule
-    {\n\t\t\taction        = \"replace\"\n\t\t\tseparator     = \"/\"\n\t\t\tsource_labels
-    = [\n\t\t\t\t\"__meta_kubernetes_pod_uid\",\n\t\t\t\t\"__meta_kubernetes_pod_container_name\",\n\t\t\t]\n\t\t\treplacement
-    \ = \"/var/log/pods/*$1/*.log\"\n\t\t\ttarget_label = \"__path__\"\n\t\t}\n\n\t\t//
-    set the __host__\n\t\trule {\n\t\t\taction        = \"replace\"\n\t\t\tsource_labels
-    = [\"__meta_kubernetes_pod_node_name\"]\n\t\t\ttarget_label  = \"__host__\"\n\t\t}\n\n\t\t//
+    = \"job\"\n\t\t}\n\n\t\t// make all labels on the pod available to the pipeline
+    as labels,\n\t\t// they are omitted before write via labelallow unless explicitly
+    set\n\t\trule {\n\t\t\taction = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_label_(.+)\"\n\t\t}\n\n\t\t//
+    make all annotations on the pod available to the pipeline as labels,\n\t\t// they
+    are omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
+    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_annotation_(.+)\"\n\t\t}\n\n\t\t//
     as a result of kubernetes service discovery for pods, all of the meta data information
     is exposed in labels\n\t\t// __meta_kubernetes_pod_*, including __meta_kubernetes_pod_container_id
     which can be used to determine what\n\t\t// the pods container runtime is, docker
@@ -362,19 +358,11 @@ data:
     automatically determined, then drop the label from the loki.process stage.\n\t\t//
     set the container runtime as a label\n\t\trule {\n\t\t\taction        = \"replace\"\n\t\t\tsource_labels
     = [\"__meta_kubernetes_pod_container_id\"]\n\t\t\tregex         = \"^(\\\\w+):\\\\/\\\\/.+$\"\n\t\t\treplacement
-    \  = \"$1\"\n\t\t\ttarget_label  = \"tmp_container_runtime\"\n\t\t}\n\n\t\t//
-    make all labels on the pod available to the pipeline as labels,\n\t\t// they are
-    omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
-    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_label_(.+)\"\n\t\t}\n\n\t\t//
-    make all annotations on the pod available to the pipeline as labels,\n\t\t// they
-    are omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
-    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_annotation_(.+)\"\n\t\t}\n\t}\n\n\t//
-    find eligible files on the worker\n\tlocal.file_match \"pods\" {\n\t\tpath_targets
-    = discovery.relabel.worker_logs.output\n\t}\n\n\t// tail the files\n\tloki.source.file
-    \"pods\" {\n\t\ttargets    = local.file_match.pods.targets\n\t\tforward_to = [loki.process.parse.receiver]\n\t}\n\n\t//
-    parse the log based on the container runtime\n\tloki.process \"parse\" {\n\t\tforward_to
-    = argument.forward_to.value\n\t\t/*******************************************************************************\n
-    \    *                         Container Runtime Parsing\n     ********************************************************************************/\n\t\t//
+    \  = \"$1\"\n\t\t\ttarget_label  = \"tmp_container_runtime\"\n\t\t}\n\t}\n\n\tloki.source.kubernetes
+    \"lsd_kubernetes_logs\" {\n\t\ttargets    = discovery.relabel.annotation_logs_filter.output\n\t\tforward_to
+    = [loki.process.parse.receiver]\n\t}\n\n\t// parse the log based on the container
+    runtime\n\tloki.process \"parse\" {\n\t\tforward_to = argument.forward_to.value\n\t\t/*******************************************************************************\n\t\t*
+    \                        Container Runtime Parsing\n\t\t********************************************************************************/\n\t\t//
     if the label tmp_container_runtime from above is containerd parse using cri\n\t\tstage.match
     {\n\t\t\tselector = \"{tmp_container_runtime=\\\"containerd\\\"}\"\n\t\t\t// the
     cri processing stage extracts the following k/v pairs: log, stream, time, flags\n\t\t\tstage.cri
@@ -410,7 +398,7 @@ data:
     \"receiver\" {\n\t\tvalue = loki.process.keep_labels.receiver\n\t}\n}\n"
 kind: ConfigMap
 metadata:
-  name: alloy-modules-kubernetes-logs-dfhkhc94gt
+  name: alloy-modules-kubernetes-logs-d7c756mt2f
   namespace: monitoring-system
 ---
 apiVersion: v1
@@ -1369,6 +1357,130 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
+    app.kubernetes.io/instance: alloy
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/version: v1.0.0
+    helm.sh/chart: alloy-0.1.1
+  name: alloy
+  namespace: monitoring-system
+spec:
+  minReadySeconds: 10
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: alloy
+      app.kubernetes.io/name: alloy
+  serviceName: alloy
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: alloy
+        logs.agent.grafana.com/scrape: "true"
+        logs.agent.grafana.com/scrub-level: debug
+        profiles.grafana.com/cpu.port_name: http-metrics
+        profiles.grafana.com/cpu.scrape: "false"
+        profiles.grafana.com/goroutine.port_name: http-metrics
+        profiles.grafana.com/goroutine.scrape: "false"
+        profiles.grafana.com/memory.port_name: http-metrics
+        profiles.grafana.com/memory.scrape: "false"
+        pyroscope.io/service_name: alloy
+      labels:
+        app.kubernetes.io/instance: alloy
+        app.kubernetes.io/name: alloy
+    spec:
+      containers:
+      - args:
+        - run
+        - /etc/alloy/config.alloy
+        - --storage.path=/tmp/alloy
+        - --server.http.listen-addr=0.0.0.0:12345
+        - --server.http.ui-path-prefix=/
+        - --disable-reporting
+        - --cluster.enabled=true
+        - --cluster.join-addresses=alloy-cluster
+        - --stability.level=experimental
+        env:
+        - name: ALLOY_DEPLOY_MODE
+          value: helm
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        envFrom:
+        - secretRef:
+            name: alloy-env
+            optional: true
+        image: docker.io/grafana/alloy:v1.0.0
+        imagePullPolicy: IfNotPresent
+        name: alloy
+        ports:
+        - containerPort: 12345
+          name: http-metrics
+        - containerPort: 4317
+          name: grpc-otlp
+          protocol: TCP
+        - containerPort: 4318
+          name: http-otlp
+          protocol: TCP
+        - containerPort: 9411
+          name: zipkin
+          protocol: TCP
+        - containerPort: 6831
+          name: jaeger-compact
+          protocol: UDP
+        readinessProbe:
+          httpGet:
+            path: /-/ready
+            port: 12345
+            scheme: HTTP
+          initialDelaySeconds: 10
+          timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /etc/alloy
+          name: config
+        - mountPath: /etc/alloy/modules/kubernetes/metrics
+          name: modules-kubernetes-metrics
+        - mountPath: /etc/alloy/modules/kubernetes/integrations
+          name: modules-kubernetes-integrations
+        - mountPath: /etc/alloy/modules/kubernetes/logs
+          name: modules-kubernetes-logs
+        - mountPath: /etc/alloy/modules/kubernetes/traces
+          name: modules-kubernetes-traces
+        - mountPath: /etc/alloy/modules/kubernetes/profiles
+          name: modules-kubernetes-profiles
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: alloy
+      volumes:
+      - configMap:
+          name: alloy-config-gt2k68744f
+        name: config
+      - configMap:
+          name: alloy-modules-kubernetes-metrics-tf9cd8b6bg
+        name: modules-kubernetes-metrics
+      - configMap:
+          name: alloy-modules-kubernetes-integrations-9k86fb8hkg
+        name: modules-kubernetes-integrations
+      - configMap:
+          name: alloy-modules-kubernetes-logs-d7c756mt2f
+        name: modules-kubernetes-logs
+      - configMap:
+          name: alloy-modules-kubernetes-traces-8mgm8th9m5
+        name: modules-kubernetes-traces
+      - configMap:
+          name: alloy-modules-kubernetes-profiles-66c27bc84g
+        name: modules-kubernetes-profiles
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
     app.kubernetes.io/instance: tempo
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tempo
@@ -1453,135 +1565,6 @@ spec:
       - emptyDir: {}
         name: tmp
   updateStrategy:
-    type: RollingUpdate
----
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  labels:
-    app.kubernetes.io/instance: alloy
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: alloy
-    app.kubernetes.io/version: v1.0.0
-    helm.sh/chart: alloy-0.1.1
-  name: alloy
-  namespace: monitoring-system
-spec:
-  minReadySeconds: 10
-  selector:
-    matchLabels:
-      app.kubernetes.io/instance: alloy
-      app.kubernetes.io/name: alloy
-  template:
-    metadata:
-      annotations:
-        kubectl.kubernetes.io/default-container: alloy
-        logs.agent.grafana.com/scrape: "true"
-        logs.agent.grafana.com/scrub-level: debug
-        profiles.grafana.com/cpu.port_name: http-metrics
-        profiles.grafana.com/cpu.scrape: "false"
-        profiles.grafana.com/goroutine.port_name: http-metrics
-        profiles.grafana.com/goroutine.scrape: "false"
-        profiles.grafana.com/memory.port_name: http-metrics
-        profiles.grafana.com/memory.scrape: "false"
-        pyroscope.io/service_name: alloy
-      labels:
-        app.kubernetes.io/instance: alloy
-        app.kubernetes.io/name: alloy
-    spec:
-      containers:
-      - args:
-        - run
-        - /etc/alloy/config.alloy
-        - --storage.path=/tmp/alloy
-        - --server.http.listen-addr=0.0.0.0:12345
-        - --server.http.ui-path-prefix=/
-        - --disable-reporting
-        - --cluster.enabled=true
-        - --cluster.join-addresses=alloy-cluster
-        - --stability.level=experimental
-        env:
-        - name: ALLOY_DEPLOY_MODE
-          value: helm
-        - name: HOSTNAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        envFrom:
-        - secretRef:
-            name: alloy-env
-            optional: true
-        image: docker.io/grafana/alloy:v1.0.0
-        imagePullPolicy: IfNotPresent
-        name: alloy
-        ports:
-        - containerPort: 12345
-          name: http-metrics
-        - containerPort: 4317
-          name: grpc-otlp
-          protocol: TCP
-        - containerPort: 4318
-          name: http-otlp
-          protocol: TCP
-        - containerPort: 9411
-          name: zipkin
-          protocol: TCP
-        - containerPort: 6831
-          name: jaeger-compact
-          protocol: UDP
-        readinessProbe:
-          httpGet:
-            path: /-/ready
-            port: 12345
-            scheme: HTTP
-          initialDelaySeconds: 10
-          timeoutSeconds: 1
-        volumeMounts:
-        - mountPath: /etc/alloy
-          name: config
-        - mountPath: /var/log
-          name: varlog
-          readOnly: true
-        - mountPath: /etc/alloy/modules/kubernetes/metrics
-          name: modules-kubernetes-metrics
-        - mountPath: /etc/alloy/modules/kubernetes/integrations
-          name: modules-kubernetes-integrations
-        - mountPath: /etc/alloy/modules/kubernetes/logs
-          name: modules-kubernetes-logs
-        - mountPath: /etc/alloy/modules/kubernetes/traces
-          name: modules-kubernetes-traces
-        - mountPath: /etc/alloy/modules/kubernetes/profiles
-          name: modules-kubernetes-profiles
-      dnsPolicy: ClusterFirst
-      nodeSelector:
-        kubernetes.io/os: linux
-      serviceAccountName: alloy
-      volumes:
-      - configMap:
-          name: alloy-config-gt2k68744f
-        name: config
-      - hostPath:
-          path: /var/log
-        name: varlog
-      - configMap:
-          name: alloy-modules-kubernetes-metrics-tf9cd8b6bg
-        name: modules-kubernetes-metrics
-      - configMap:
-          name: alloy-modules-kubernetes-integrations-9k86fb8hkg
-        name: modules-kubernetes-integrations
-      - configMap:
-          name: alloy-modules-kubernetes-logs-dfhkhc94gt
-        name: modules-kubernetes-logs
-      - configMap:
-          name: alloy-modules-kubernetes-traces-8mgm8th9m5
-        name: modules-kubernetes-traces
-      - configMap:
-          name: alloy-modules-kubernetes-profiles-66c27bc84g
-        name: modules-kubernetes-profiles
-  updateStrategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 2
     type: RollingUpdate
 ---
 apiVersion: monitoring.coreos.com/v1

--- a/kubernetes/read-write-mode/logs/k8s-all-in-one.yaml
+++ b/kubernetes/read-write-mode/logs/k8s-all-in-one.yaml
@@ -444,15 +444,14 @@ data:
     to look for targets in (default: [\\\"kube-system\\\"] is all namespaces)\"\n\t\toptional
     = true\n\t}\n\n\targument \"annotation_prefix\" {\n\t\tcomment  = \"The annotation_prefix
     to use (default: logs.grafana.com)\"\n\t\tdefault  = \"logs.grafana.com\"\n\t\toptional
-    = true\n\t}\n\n\t/*\n    Hidden Arguments\n    These arguments are used to set
-    reusable variables to avoid repeating logic\n  */\n\targument \"__sd_annotation\"
-    {\n\t\toptional = true\n\t\tcomment  = \"The logic is used to transform the annotation
-    argument into a valid label name by removing unsupported characters.\"\n\t\tdefault
-    \ = replace(replace(replace(coalesce(argument.annotation_prefix.value, \"logs.grafana.com\"),
-    \".\", \"_\"), \"/\", \"_\"), \"-\", \"_\")\n\t}\n\n\t// find all pods\n\tdiscovery.kubernetes
-    \"log_annotations\" {\n\t\trole = \"pod\"\n\n\t\tnamespaces {\n\t\t\tnames = coalesce(argument.namespaces.value,
-    [])\n\t\t}\n\t}\n\n\t// apply relabelings\n\tdiscovery.relabel \"log_annotations\"
-    {\n\t\ttargets = discovery.kubernetes.log_annotations.targets\n\n\t\t// allow
+    = true\n\t}\n\n\targument \"__sd_annotation\" {\n\t\toptional = true\n\t\tcomment
+    \ = \"The logic is used to transform the annotation argument into a valid label
+    name by removing unsupported characters.\"\n\t\tdefault  = replace(replace(replace(coalesce(argument.annotation_prefix.value,
+    \"logs.grafana.com\"), \".\", \"_\"), \"/\", \"_\"), \"-\", \"_\")\n\t}\n\n\t//
+    find all pods\n\tdiscovery.kubernetes \"annotation_logs\" {\n\t\trole = \"pod\"\n\n\t\tnamespaces
+    {\n\t\t\tnames = coalesce(argument.namespaces.value, [])\n\t\t}\n\t}\n\n\t// filter
+    logs by kubernetes annotations\n\tdiscovery.relabel \"annotation_logs_filter\"
+    {\n\t\ttargets = discovery.kubernetes.annotation_logs.targets\n\n\t\t// allow
     pods to declare their logs to be ingested or not, the default is true\n\t\t//
     \  i.e. logs.grafana.com/ingest: false\n\t\trule {\n\t\t\taction        = \"keep\"\n\t\t\tsource_labels
     = [\n\t\t\t\t\"__meta_kubernetes_pod_annotation_\" + argument.__sd_annotation.value
@@ -490,15 +489,12 @@ data:
     set the job label to be namespace / friendly pod name\n\t\trule {\n\t\t\taction
     \       = \"replace\"\n\t\t\tsource_labels = [\n\t\t\t\t\"workload\",\n\t\t\t\t\"__meta_kubernetes_namespace\",\n\t\t\t]\n\t\t\tregex
     \       = \".+\\\\/(.+);(.+)\"\n\t\t\treplacement  = \"$2/$1\"\n\t\t\ttarget_label
-    = \"job\"\n\t\t}\n\t}\n\n\tdiscovery.relabel \"worker_logs\" {\n\t\ttargets =
-    discovery.relabel.log_annotations.output\n\n\t\t// set the __path__, this is automatically
-    translated as a label of filename (which should be dropped or normalized)\n\t\t//
-    DO NOT delete this line as it is needed to tail the pod logs on the node\n\t\trule
-    {\n\t\t\taction        = \"replace\"\n\t\t\tseparator     = \"/\"\n\t\t\tsource_labels
-    = [\n\t\t\t\t\"__meta_kubernetes_pod_uid\",\n\t\t\t\t\"__meta_kubernetes_pod_container_name\",\n\t\t\t]\n\t\t\treplacement
-    \ = \"/var/log/pods/*$1/*.log\"\n\t\t\ttarget_label = \"__path__\"\n\t\t}\n\n\t\t//
-    set the __host__\n\t\trule {\n\t\t\taction        = \"replace\"\n\t\t\tsource_labels
-    = [\"__meta_kubernetes_pod_node_name\"]\n\t\t\ttarget_label  = \"__host__\"\n\t\t}\n\n\t\t//
+    = \"job\"\n\t\t}\n\n\t\t// make all labels on the pod available to the pipeline
+    as labels,\n\t\t// they are omitted before write via labelallow unless explicitly
+    set\n\t\trule {\n\t\t\taction = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_label_(.+)\"\n\t\t}\n\n\t\t//
+    make all annotations on the pod available to the pipeline as labels,\n\t\t// they
+    are omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
+    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_annotation_(.+)\"\n\t\t}\n\n\t\t//
     as a result of kubernetes service discovery for pods, all of the meta data information
     is exposed in labels\n\t\t// __meta_kubernetes_pod_*, including __meta_kubernetes_pod_container_id
     which can be used to determine what\n\t\t// the pods container runtime is, docker
@@ -509,19 +505,11 @@ data:
     automatically determined, then drop the label from the loki.process stage.\n\t\t//
     set the container runtime as a label\n\t\trule {\n\t\t\taction        = \"replace\"\n\t\t\tsource_labels
     = [\"__meta_kubernetes_pod_container_id\"]\n\t\t\tregex         = \"^(\\\\w+):\\\\/\\\\/.+$\"\n\t\t\treplacement
-    \  = \"$1\"\n\t\t\ttarget_label  = \"tmp_container_runtime\"\n\t\t}\n\n\t\t//
-    make all labels on the pod available to the pipeline as labels,\n\t\t// they are
-    omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
-    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_label_(.+)\"\n\t\t}\n\n\t\t//
-    make all annotations on the pod available to the pipeline as labels,\n\t\t// they
-    are omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
-    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_annotation_(.+)\"\n\t\t}\n\t}\n\n\t//
-    find eligible files on the worker\n\tlocal.file_match \"pods\" {\n\t\tpath_targets
-    = discovery.relabel.worker_logs.output\n\t}\n\n\t// tail the files\n\tloki.source.file
-    \"pods\" {\n\t\ttargets    = local.file_match.pods.targets\n\t\tforward_to = [loki.process.parse.receiver]\n\t}\n\n\t//
-    parse the log based on the container runtime\n\tloki.process \"parse\" {\n\t\tforward_to
-    = argument.forward_to.value\n\t\t/*******************************************************************************\n
-    \    *                         Container Runtime Parsing\n     ********************************************************************************/\n\t\t//
+    \  = \"$1\"\n\t\t\ttarget_label  = \"tmp_container_runtime\"\n\t\t}\n\t}\n\n\tloki.source.kubernetes
+    \"lsd_kubernetes_logs\" {\n\t\ttargets    = discovery.relabel.annotation_logs_filter.output\n\t\tforward_to
+    = [loki.process.parse.receiver]\n\t}\n\n\t// parse the log based on the container
+    runtime\n\tloki.process \"parse\" {\n\t\tforward_to = argument.forward_to.value\n\t\t/*******************************************************************************\n\t\t*
+    \                        Container Runtime Parsing\n\t\t********************************************************************************/\n\t\t//
     if the label tmp_container_runtime from above is containerd parse using cri\n\t\tstage.match
     {\n\t\t\tselector = \"{tmp_container_runtime=\\\"containerd\\\"}\"\n\t\t\t// the
     cri processing stage extracts the following k/v pairs: log, stream, time, flags\n\t\t\tstage.cri
@@ -557,7 +545,7 @@ data:
     \"receiver\" {\n\t\tvalue = loki.process.keep_labels.receiver\n\t}\n}\n"
 kind: ConfigMap
 metadata:
-  name: alloy-modules-kubernetes-logs-dfhkhc94gt
+  name: alloy-modules-kubernetes-logs-d7c756mt2f
   namespace: monitoring-system
 ---
 apiVersion: v1
@@ -1883,68 +1871,8 @@ spec:
     rollingUpdate:
       partition: 0
 ---
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  labels:
-    app.kubernetes.io/component: backend
-    app.kubernetes.io/instance: loki
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: loki
-    app.kubernetes.io/version: 3.0.0
-    helm.sh/chart: loki-6.1.0
-  name: loki-backend
-  namespace: logging-system
-spec:
-  maxUnavailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/component: backend
-      app.kubernetes.io/instance: loki
-      app.kubernetes.io/name: loki
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  labels:
-    app.kubernetes.io/component: read
-    app.kubernetes.io/instance: loki
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: loki
-    app.kubernetes.io/version: 3.0.0
-    helm.sh/chart: loki-6.1.0
-  name: loki-read
-  namespace: logging-system
-spec:
-  maxUnavailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/component: read
-      app.kubernetes.io/instance: loki
-      app.kubernetes.io/name: loki
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  labels:
-    app.kubernetes.io/component: write
-    app.kubernetes.io/instance: loki
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: loki
-    app.kubernetes.io/version: 3.0.0
-    helm.sh/chart: loki-6.1.0
-  name: loki-write
-  namespace: logging-system
-spec:
-  maxUnavailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/component: write
-      app.kubernetes.io/instance: loki
-      app.kubernetes.io/name: loki
----
 apiVersion: apps/v1
-kind: DaemonSet
+kind: StatefulSet
 metadata:
   labels:
     app.kubernetes.io/instance: alloy
@@ -1956,10 +1884,16 @@ metadata:
   namespace: monitoring-system
 spec:
   minReadySeconds: 10
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  podManagementPolicy: Parallel
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: alloy
       app.kubernetes.io/name: alloy
+  serviceName: alloy
   template:
     metadata:
       annotations:
@@ -2027,9 +1961,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/alloy
           name: config
-        - mountPath: /var/log
-          name: varlog
-          readOnly: true
         - mountPath: /etc/alloy/modules/kubernetes/metrics
           name: modules-kubernetes-metrics
         - mountPath: /etc/alloy/modules/kubernetes/integrations
@@ -2048,9 +1979,6 @@ spec:
       - configMap:
           name: alloy-config-8t9d8htff7
         name: config
-      - hostPath:
-          path: /var/log
-        name: varlog
       - configMap:
           name: alloy-modules-kubernetes-metrics-tf9cd8b6bg
         name: modules-kubernetes-metrics
@@ -2058,7 +1986,7 @@ spec:
           name: alloy-modules-kubernetes-integrations-9k86fb8hkg
         name: modules-kubernetes-integrations
       - configMap:
-          name: alloy-modules-kubernetes-logs-dfhkhc94gt
+          name: alloy-modules-kubernetes-logs-d7c756mt2f
         name: modules-kubernetes-logs
       - configMap:
           name: alloy-modules-kubernetes-traces-8mgm8th9m5
@@ -2066,11 +1994,66 @@ spec:
       - configMap:
           name: alloy-modules-kubernetes-profiles-66c27bc84g
         name: modules-kubernetes-profiles
-  updateStrategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 2
-    type: RollingUpdate
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/version: 3.0.0
+    helm.sh/chart: loki-6.1.0
+  name: loki-backend
+  namespace: logging-system
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: backend
+      app.kubernetes.io/instance: loki
+      app.kubernetes.io/name: loki
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: read
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/version: 3.0.0
+    helm.sh/chart: loki-6.1.0
+  name: loki-read
+  namespace: logging-system
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: read
+      app.kubernetes.io/instance: loki
+      app.kubernetes.io/name: loki
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: write
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/version: 3.0.0
+    helm.sh/chart: loki-6.1.0
+  name: loki-write
+  namespace: logging-system
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: write
+      app.kubernetes.io/instance: loki
+      app.kubernetes.io/name: loki
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/kubernetes/read-write-mode/metrics/k8s-all-in-one.yaml
+++ b/kubernetes/read-write-mode/metrics/k8s-all-in-one.yaml
@@ -222,15 +222,14 @@ data:
     to look for targets in (default: [\\\"kube-system\\\"] is all namespaces)\"\n\t\toptional
     = true\n\t}\n\n\targument \"annotation_prefix\" {\n\t\tcomment  = \"The annotation_prefix
     to use (default: logs.grafana.com)\"\n\t\tdefault  = \"logs.grafana.com\"\n\t\toptional
-    = true\n\t}\n\n\t/*\n    Hidden Arguments\n    These arguments are used to set
-    reusable variables to avoid repeating logic\n  */\n\targument \"__sd_annotation\"
-    {\n\t\toptional = true\n\t\tcomment  = \"The logic is used to transform the annotation
-    argument into a valid label name by removing unsupported characters.\"\n\t\tdefault
-    \ = replace(replace(replace(coalesce(argument.annotation_prefix.value, \"logs.grafana.com\"),
-    \".\", \"_\"), \"/\", \"_\"), \"-\", \"_\")\n\t}\n\n\t// find all pods\n\tdiscovery.kubernetes
-    \"log_annotations\" {\n\t\trole = \"pod\"\n\n\t\tnamespaces {\n\t\t\tnames = coalesce(argument.namespaces.value,
-    [])\n\t\t}\n\t}\n\n\t// apply relabelings\n\tdiscovery.relabel \"log_annotations\"
-    {\n\t\ttargets = discovery.kubernetes.log_annotations.targets\n\n\t\t// allow
+    = true\n\t}\n\n\targument \"__sd_annotation\" {\n\t\toptional = true\n\t\tcomment
+    \ = \"The logic is used to transform the annotation argument into a valid label
+    name by removing unsupported characters.\"\n\t\tdefault  = replace(replace(replace(coalesce(argument.annotation_prefix.value,
+    \"logs.grafana.com\"), \".\", \"_\"), \"/\", \"_\"), \"-\", \"_\")\n\t}\n\n\t//
+    find all pods\n\tdiscovery.kubernetes \"annotation_logs\" {\n\t\trole = \"pod\"\n\n\t\tnamespaces
+    {\n\t\t\tnames = coalesce(argument.namespaces.value, [])\n\t\t}\n\t}\n\n\t// filter
+    logs by kubernetes annotations\n\tdiscovery.relabel \"annotation_logs_filter\"
+    {\n\t\ttargets = discovery.kubernetes.annotation_logs.targets\n\n\t\t// allow
     pods to declare their logs to be ingested or not, the default is true\n\t\t//
     \  i.e. logs.grafana.com/ingest: false\n\t\trule {\n\t\t\taction        = \"keep\"\n\t\t\tsource_labels
     = [\n\t\t\t\t\"__meta_kubernetes_pod_annotation_\" + argument.__sd_annotation.value
@@ -268,15 +267,12 @@ data:
     set the job label to be namespace / friendly pod name\n\t\trule {\n\t\t\taction
     \       = \"replace\"\n\t\t\tsource_labels = [\n\t\t\t\t\"workload\",\n\t\t\t\t\"__meta_kubernetes_namespace\",\n\t\t\t]\n\t\t\tregex
     \       = \".+\\\\/(.+);(.+)\"\n\t\t\treplacement  = \"$2/$1\"\n\t\t\ttarget_label
-    = \"job\"\n\t\t}\n\t}\n\n\tdiscovery.relabel \"worker_logs\" {\n\t\ttargets =
-    discovery.relabel.log_annotations.output\n\n\t\t// set the __path__, this is automatically
-    translated as a label of filename (which should be dropped or normalized)\n\t\t//
-    DO NOT delete this line as it is needed to tail the pod logs on the node\n\t\trule
-    {\n\t\t\taction        = \"replace\"\n\t\t\tseparator     = \"/\"\n\t\t\tsource_labels
-    = [\n\t\t\t\t\"__meta_kubernetes_pod_uid\",\n\t\t\t\t\"__meta_kubernetes_pod_container_name\",\n\t\t\t]\n\t\t\treplacement
-    \ = \"/var/log/pods/*$1/*.log\"\n\t\t\ttarget_label = \"__path__\"\n\t\t}\n\n\t\t//
-    set the __host__\n\t\trule {\n\t\t\taction        = \"replace\"\n\t\t\tsource_labels
-    = [\"__meta_kubernetes_pod_node_name\"]\n\t\t\ttarget_label  = \"__host__\"\n\t\t}\n\n\t\t//
+    = \"job\"\n\t\t}\n\n\t\t// make all labels on the pod available to the pipeline
+    as labels,\n\t\t// they are omitted before write via labelallow unless explicitly
+    set\n\t\trule {\n\t\t\taction = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_label_(.+)\"\n\t\t}\n\n\t\t//
+    make all annotations on the pod available to the pipeline as labels,\n\t\t// they
+    are omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
+    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_annotation_(.+)\"\n\t\t}\n\n\t\t//
     as a result of kubernetes service discovery for pods, all of the meta data information
     is exposed in labels\n\t\t// __meta_kubernetes_pod_*, including __meta_kubernetes_pod_container_id
     which can be used to determine what\n\t\t// the pods container runtime is, docker
@@ -287,19 +283,11 @@ data:
     automatically determined, then drop the label from the loki.process stage.\n\t\t//
     set the container runtime as a label\n\t\trule {\n\t\t\taction        = \"replace\"\n\t\t\tsource_labels
     = [\"__meta_kubernetes_pod_container_id\"]\n\t\t\tregex         = \"^(\\\\w+):\\\\/\\\\/.+$\"\n\t\t\treplacement
-    \  = \"$1\"\n\t\t\ttarget_label  = \"tmp_container_runtime\"\n\t\t}\n\n\t\t//
-    make all labels on the pod available to the pipeline as labels,\n\t\t// they are
-    omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
-    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_label_(.+)\"\n\t\t}\n\n\t\t//
-    make all annotations on the pod available to the pipeline as labels,\n\t\t// they
-    are omitted before write via labelallow unless explicitly set\n\t\trule {\n\t\t\taction
-    = \"labelmap\"\n\t\t\tregex  = \"__meta_kubernetes_pod_annotation_(.+)\"\n\t\t}\n\t}\n\n\t//
-    find eligible files on the worker\n\tlocal.file_match \"pods\" {\n\t\tpath_targets
-    = discovery.relabel.worker_logs.output\n\t}\n\n\t// tail the files\n\tloki.source.file
-    \"pods\" {\n\t\ttargets    = local.file_match.pods.targets\n\t\tforward_to = [loki.process.parse.receiver]\n\t}\n\n\t//
-    parse the log based on the container runtime\n\tloki.process \"parse\" {\n\t\tforward_to
-    = argument.forward_to.value\n\t\t/*******************************************************************************\n
-    \    *                         Container Runtime Parsing\n     ********************************************************************************/\n\t\t//
+    \  = \"$1\"\n\t\t\ttarget_label  = \"tmp_container_runtime\"\n\t\t}\n\t}\n\n\tloki.source.kubernetes
+    \"lsd_kubernetes_logs\" {\n\t\ttargets    = discovery.relabel.annotation_logs_filter.output\n\t\tforward_to
+    = [loki.process.parse.receiver]\n\t}\n\n\t// parse the log based on the container
+    runtime\n\tloki.process \"parse\" {\n\t\tforward_to = argument.forward_to.value\n\t\t/*******************************************************************************\n\t\t*
+    \                        Container Runtime Parsing\n\t\t********************************************************************************/\n\t\t//
     if the label tmp_container_runtime from above is containerd parse using cri\n\t\tstage.match
     {\n\t\t\tselector = \"{tmp_container_runtime=\\\"containerd\\\"}\"\n\t\t\t// the
     cri processing stage extracts the following k/v pairs: log, stream, time, flags\n\t\t\tstage.cri
@@ -335,7 +323,7 @@ data:
     \"receiver\" {\n\t\tvalue = loki.process.keep_labels.receiver\n\t}\n}\n"
 kind: ConfigMap
 metadata:
-  name: alloy-modules-kubernetes-logs-dfhkhc94gt
+  name: alloy-modules-kubernetes-logs-d7c756mt2f
   namespace: monitoring-system
 ---
 apiVersion: v1
@@ -1258,7 +1246,7 @@ spec:
         name: storage
 ---
 apiVersion: apps/v1
-kind: DaemonSet
+kind: StatefulSet
 metadata:
   labels:
     app.kubernetes.io/instance: alloy
@@ -1270,10 +1258,16 @@ metadata:
   namespace: monitoring-system
 spec:
   minReadySeconds: 10
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  podManagementPolicy: Parallel
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: alloy
       app.kubernetes.io/name: alloy
+  serviceName: alloy
   template:
     metadata:
       annotations:
@@ -1341,9 +1335,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/alloy
           name: config
-        - mountPath: /var/log
-          name: varlog
-          readOnly: true
         - mountPath: /etc/alloy/modules/kubernetes/metrics
           name: modules-kubernetes-metrics
         - mountPath: /etc/alloy/modules/kubernetes/integrations
@@ -1362,9 +1353,6 @@ spec:
       - configMap:
           name: alloy-config-m6chdfm49m
         name: config
-      - hostPath:
-          path: /var/log
-        name: varlog
       - configMap:
           name: alloy-modules-kubernetes-metrics-tf9cd8b6bg
         name: modules-kubernetes-metrics
@@ -1372,7 +1360,7 @@ spec:
           name: alloy-modules-kubernetes-integrations-9k86fb8hkg
         name: modules-kubernetes-integrations
       - configMap:
-          name: alloy-modules-kubernetes-logs-dfhkhc94gt
+          name: alloy-modules-kubernetes-logs-d7c756mt2f
         name: modules-kubernetes-logs
       - configMap:
           name: alloy-modules-kubernetes-traces-8mgm8th9m5
@@ -1380,11 +1368,6 @@ spec:
       - configMap:
           name: alloy-modules-kubernetes-profiles-66c27bc84g
         name: modules-kubernetes-profiles
-  updateStrategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 2
-    type: RollingUpdate
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor


### PR DESCRIPTION
Signed-off-by: Weifeng Wang <qclaogui@gmail.com>

- Use [`loki.source.kubernetes`](https://grafana.com/docs/alloy/latest/reference/components/loki.source.kubernetes/) instead of `loki.source.file`
- Change type of controller for deploying Grafana Alloy from `daemonset` to `statefulset`.
 