### PR TITLE
Support for health checks using CMD rather than CMD-SHELL

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -57,7 +57,7 @@ services:
       - ./docker-compose/common/config/mimir/gateway_mimir.conf:/etc/nginx/templates/gateway_mimir.conf.template
       - ./docker-compose/common/config/pyroscope/gateway_pyroscope.conf:/etc/nginx/templates/gateway_pyroscope.conf.template
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/ || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/" ]
       interval: 3s
       timeout: 1s
       retries: 20

--- a/docker-compose/common/compose-include/loki.yaml
+++ b/docker-compose/common/compose-include/loki.yaml
@@ -14,7 +14,7 @@ services:
       - -target=all
       - -config.expand-env=true
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3100/ready || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3100/ready" ]
       interval: 3s
       timeout: 1s
       retries: 15

--- a/docker-compose/common/compose-include/mimir.yaml
+++ b/docker-compose/common/compose-include/mimir.yaml
@@ -15,7 +15,7 @@ services:
       - -target=all
       - -config.expand-env=true
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/ready || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/ready" ]
       interval: 3s
       timeout: 1s
       retries: 15

--- a/docker-compose/common/compose-include/pyroscope.yaml
+++ b/docker-compose/common/compose-include/pyroscope.yaml
@@ -19,7 +19,10 @@ services:
       - -config.expand-env=true
       # - -runtime-config.file=/etc/pyroscope/configs/overrides.yaml
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:4040/ready || exit 1" ]
+      ## execute the `test` in a shell use the form `["CMD-SHELL", "command"]`
+      # test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:4040/ready || exit 1" ]
+      ## execute the `test` without a shell, use the form: `["CMD", "command", "arg1", "arg2"]`
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:4040/ready" ]
       interval: 2s
       timeout: 1s
       retries: 15

--- a/docker-compose/common/compose-include/tempo.yaml
+++ b/docker-compose/common/compose-include/tempo.yaml
@@ -15,7 +15,7 @@ services:
       - -target=all
       - -config.expand-env=true
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3200/ready || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3200/ready" ]
       interval: 3s
       timeout: 1s
       retries: 15

--- a/docker-compose/microservices-mode/logs/compose.yaml
+++ b/docker-compose/microservices-mode/logs/compose.yaml
@@ -52,7 +52,7 @@ services:
       - LOKI_QUERIER_HOST=querier
       - LOKI_COMPACTOR_HOST=compactor
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3100/ || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3100/" ]
       interval: 3s
       timeout: 1s
       retries: 20
@@ -73,7 +73,7 @@ services:
       - -target=distributor
       - -config.expand-env=true
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3100/ready || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3100/ready" ]
       <<: *status-healthcheck
     deploy:
       replicas: 2
@@ -96,7 +96,7 @@ services:
       - -target=ingester
       - -config.expand-env=true
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3100/ready || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3100/ready" ]
       <<: *status-healthcheck
     deploy:
       replicas: 3
@@ -119,7 +119,7 @@ services:
       - -target=pattern-ingester
       - -config.expand-env=true
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3100/ready || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3100/ready" ]
       <<: *status-healthcheck
     deploy:
       replicas: 1
@@ -169,7 +169,7 @@ services:
       - -target=query-scheduler
       - -config.expand-env=true
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3100/ready || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3100/ready" ]
       <<: *status-healthcheck
     deploy:
       replicas: 2

--- a/docker-compose/microservices-mode/metrics/compose.yaml
+++ b/docker-compose/microservices-mode/metrics/compose.yaml
@@ -41,7 +41,7 @@ services:
       - MIMIR_QUERY_FRONTEND_HOST=query-frontend
       - MIMIR_COMPACTOR_HOST=compactor
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/ || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/" ]
       interval: 3s
       timeout: 1s
       retries: 20
@@ -61,7 +61,7 @@ services:
       - -target=distributor
       - -config.expand-env=true
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/ready || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/ready" ]
       <<: *status-healthcheck
     deploy:
       replicas: 2
@@ -126,7 +126,7 @@ services:
       - -config.expand-env=true
       - -target=query-scheduler
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/ready || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/ready" ]
       <<: *status-healthcheck
     deploy:
       replicas: 2
@@ -144,7 +144,7 @@ services:
       - -config.expand-env=true
       - -target=ruler
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/ready || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/ready" ]
       <<: *status-healthcheck
     networks:
       default:
@@ -198,7 +198,7 @@ services:
       - -config.expand-env=true
       - -target=ingester
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/ready || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/ready" ]
       <<: *status-healthcheck
     deploy:
       replicas: 3

--- a/docker-compose/microservices-mode/profiles/compose.yaml
+++ b/docker-compose/microservices-mode/profiles/compose.yaml
@@ -50,7 +50,7 @@ services:
       - PYROSCOPE_DISTRIBUTOR_HOST=distributor
       - PYROSCOPE_QUERY_FRONTEND_HOST=query-frontend
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:4040/ || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:4040/" ]
       interval: 3s
       timeout: 1s
       retries: 20
@@ -77,7 +77,7 @@ services:
       - -memberlist.join=pyroscope-memberlist:7946
       # - -runtime-config.file=/etc/pyroscope/configs/overrides.yaml
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:4040/ready || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:4040/ready" ]
       <<: *status-healthcheck
     networks:
       default:
@@ -103,7 +103,7 @@ services:
       - -memberlist.cluster-label=profiles-system
       - -memberlist.join=pyroscope-memberlist:7946
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:4040/ready || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:4040/ready" ]
       <<: *status-healthcheck
     deploy:
       replicas: 3

--- a/docker-compose/microservices-mode/traces/compose.yaml
+++ b/docker-compose/microservices-mode/traces/compose.yaml
@@ -79,7 +79,7 @@ services:
       <<: *jaeger-environment
       JAEGER_TAGS: app=distributor
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3200/ready || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3200/ready" ]
       <<: *status-healthcheck
 
   ingester:
@@ -98,7 +98,7 @@ services:
       <<: *jaeger-environment
       JAEGER_TAGS: app=ingester
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3200/ready || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3200/ready" ]
       <<: *status-healthcheck
     deploy:
       replicas: 3

--- a/docker-compose/monolithic-mode/all-in-one/compose.yaml
+++ b/docker-compose/monolithic-mode/all-in-one/compose.yaml
@@ -57,7 +57,7 @@ services:
       - ../../common/config/mimir/gateway_mimir.conf:/etc/nginx/templates/gateway_mimir.conf.template
       - ../../common/config/pyroscope/gateway_pyroscope.conf:/etc/nginx/templates/gateway_pyroscope.conf.template
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/ || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/" ]
       interval: 3s
       timeout: 1s
       retries: 20
@@ -82,7 +82,7 @@ services:
       <<: *jaeger-environment
       JAEGER_TAGS: app=loki
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3100/ready || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3100/ready" ]
       <<: *status-healthcheck
     # expose 33100 port so we can directly access loki inside container
     ports:
@@ -112,7 +112,7 @@ services:
       <<: *jaeger-environment
       JAEGER_TAGS: app=tempo
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3200/ready || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3200/ready" ]
       <<: *status-healthcheck
       start_period: 10s
     # expose 33200 port so we can directly access tempo inside container
@@ -140,7 +140,7 @@ services:
       <<: *jaeger-environment
       JAEGER_TAGS: app=mimir
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/ready || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/ready" ]
       <<: *status-healthcheck
     # expose 38080 port so we can directly access mimir inside container
     ports:
@@ -185,7 +185,7 @@ services:
       <<: *jaeger-environment
       JAEGER_TAGS: app=pyroscope
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:4040/ready || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:4040/ready" ]
       <<: *status-healthcheck
     # expose 34040 port so we can directly access pyroscope inside container
     ports:

--- a/docker-compose/monolithic-mode/logs/compose.yaml
+++ b/docker-compose/monolithic-mode/logs/compose.yaml
@@ -34,7 +34,7 @@ services:
       - ../../common/config/loki/gateway_loki.conf:/etc/nginx/templates/gateway_loki.conf.template
       - ../../common/config/mimir/gateway_mimir.conf:/etc/nginx/templates/gateway_mimir.conf.template
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3100/ || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3100/" ]
       interval: 3s
       timeout: 1s
       retries: 20

--- a/docker-compose/monolithic-mode/metrics/compose.yaml
+++ b/docker-compose/monolithic-mode/metrics/compose.yaml
@@ -29,7 +29,7 @@ services:
       - ../../common/config/nginx/nginx.conf:/etc/nginx/templates/nginx.conf.template
       - ../../common/config/mimir/gateway_mimir.conf:/etc/nginx/templates/gateway_mimir.conf.template
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/ || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/" ]
       interval: 3s
       timeout: 1s
       retries: 20

--- a/docker-compose/monolithic-mode/profiles/compose.yaml
+++ b/docker-compose/monolithic-mode/profiles/compose.yaml
@@ -33,7 +33,7 @@ services:
       - ../../common/config/pyroscope/gateway_pyroscope.conf:/etc/nginx/templates/gateway_pyroscope.conf.template
       - ../../common/config/mimir/gateway_mimir.conf:/etc/nginx/templates/gateway_mimir.conf.template
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:4040/ || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:4040/" ]
       interval: 3s
       timeout: 1s
       retries: 20

--- a/docker-compose/read-write-mode/logs/compose.yaml
+++ b/docker-compose/read-write-mode/logs/compose.yaml
@@ -47,7 +47,7 @@ services:
       - LOKI_QUERIER_HOST=loki-read
       - LOKI_COMPACTOR_HOST=loki-backend
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3100/ || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3100/" ]
       interval: 3s
       timeout: 1s
       retries: 20
@@ -68,7 +68,7 @@ services:
       - -legacy-read-mode=false
       - -config.expand-env=true
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3100/ready || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3100/ready" ]
       <<: *status-healthcheck
     deploy:
       replicas: 2
@@ -90,7 +90,7 @@ services:
       - -target=write
       - -config.expand-env=true
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3100/ready || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3100/ready" ]
       <<: *status-healthcheck
     deploy:
       replicas: 3
@@ -113,7 +113,7 @@ services:
       - -legacy-read-mode=false
       - -config.expand-env=true
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3100/ready || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3100/ready" ]
       <<: *status-healthcheck
     deploy:
       replicas: 2

--- a/docker-compose/read-write-mode/metrics/compose.yaml
+++ b/docker-compose/read-write-mode/metrics/compose.yaml
@@ -41,7 +41,7 @@ services:
       - MIMIR_RULER_HOST=mimir-backend
       - MIMIR_COMPACTOR_HOST=mimir-backend
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/ || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/" ]
       interval: 3s
       timeout: 1s
       retries: 20
@@ -61,7 +61,7 @@ services:
       - -target=backend
       - -config.expand-env=true
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/ready || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/ready" ]
       <<: *status-healthcheck
     deploy:
       replicas: 2
@@ -95,7 +95,7 @@ services:
       - -target=write
       - -config.expand-env=true
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/ready || exit 1" ]
+      test: [ "CMD", "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/ready" ]
       <<: *status-healthcheck
     deploy:
       replicas: 3


### PR DESCRIPTION
Currently only CMD-SHELL [health checks](https://docs.docker.com/compose/compose-file/05-services/#healthcheck) are supported which require a shell on the docker container to run. distroless docker images like [mockserver](https://hub.docker.com/r/mockserver/mockserver/) don't have a shell so that mechanism doesn't work, see https://github.com/GoogleContainerTools/distroless/issues/183.

To support docker containers without a shell the health check needs to be in the format:

```shell
test: ['CMD', '/usr/bin/wget', 'arg1', 'arg2', 'arg3']
```